### PR TITLE
client: http: Add wallet auth implementation

### DIFF
--- a/client/http.go
+++ b/client/http.go
@@ -2,59 +2,113 @@ package client
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"time"
 )
 
-// Client represents an HTTP client with a base URL
+const (
+	contentTypeHeader   = "Content-Type"
+	contentTypeJSON     = "application/json"
+	signatureHeader     = "renegade-auth"
+	expirationHeader    = "renegade-auth-expiration"
+	signatureExpiration = 5 * time.Second
+)
+
+// Client represents an HTTP client with a base URL and auth key
 type Client struct {
 	baseURL    string
 	httpClient *http.Client
+	authKey    []byte
 }
 
-// NewClient creates a new Client with the given base URL
-func NewClient(baseURL string) *Client {
+// NewClient creates a new Client with the given base URL and auth key
+func NewClient(baseURL string, authKey []byte) *Client {
 	return &Client{
 		baseURL:    baseURL,
 		httpClient: &http.Client{},
+		authKey:    authKey,
 	}
 }
 
 // Get performs a GET request to the specified path
-// body is an optional JSON-marshallable request body
 func (c *Client) Get(path string, body interface{}) ([]byte, error) {
-	return c.doRequest(http.MethodGet, path, body)
+	return c.doRequest(http.MethodGet, path, body, false /* withAuth */)
 }
 
 // Post performs a POST request to the specified path
-// body is an optional JSON-marshallable request body
 func (c *Client) Post(path string, body interface{}) ([]byte, error) {
-	return c.doRequest(http.MethodPost, path, body)
+	return c.doRequest(http.MethodPost, path, body, false /* withAuth */)
 }
 
-// doRequest performs an HTTP request with the given method, path, and body
-// It returns the response body as a byte slice or an error if the request fails
-func (c *Client) doRequest(method, path string, body interface{}) ([]byte, error) {
+// GetJSON performs a GET request and unmarshals the response into the provided interface
+func (c *Client) GetJSON(path string, body interface{}, response interface{}) error {
+	respBody, err := c.doRequest(http.MethodGet, path, body, false /* withAuth */)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(respBody, response)
+}
+
+// PostJSON performs a POST request and unmarshals the response into the provided interface
+func (c *Client) PostJSON(path string, body interface{}, response interface{}) error {
+	respBody, err := c.doRequest(http.MethodPost, path, body, false /* withAuth */)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(respBody, response)
+}
+
+// GetWithAuth performs an authenticated GET request
+func (c *Client) GetWithAuth(path string, body interface{}, response interface{}) error {
+	respBody, err := c.doRequest(http.MethodGet, path, body, true /* withAuth */)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(respBody, response)
+}
+
+// PostWithAuth performs an authenticated POST request
+func (c *Client) PostWithAuth(path string, body interface{}, response interface{}) error {
+	respBody, err := c.doRequest(http.MethodPost, path, body, true /* withAuth */)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(respBody, response)
+}
+
+// doRequest performs an HTTP request with optional authentication
+func (c *Client) doRequest(method, path string, body interface{}, withAuth bool) ([]byte, error) {
 	url := fmt.Sprintf("%s%s", c.baseURL, path)
 
 	// Marshal the body
-	var reqBody io.Reader
+	var bodyBytes []byte
+	var err error
 	if body != nil {
-		jsonBody, err := json.Marshal(body)
+		bodyBytes, err = json.Marshal(body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal request body: %w", err)
 		}
-		reqBody = bytes.NewBuffer(jsonBody)
 	}
 
 	// Create the request
-	req, err := http.NewRequest(method, url, reqBody)
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+
+	// Set headers
+	req.Header.Set(contentTypeHeader, contentTypeJSON)
+	if withAuth {
+		c.addAuth(req, bodyBytes)
+	}
 
 	// Send the request
 	resp, err := c.httpClient.Do(req)
@@ -63,7 +117,7 @@ func (c *Client) doRequest(method, path string, body interface{}) ([]byte, error
 	}
 	defer resp.Body.Close()
 
-	// Read the response body
+	// Read and check the response
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
@@ -74,4 +128,20 @@ func (c *Client) doRequest(method, path string, body interface{}) ([]byte, error
 	}
 
 	return respBody, nil
+}
+
+// addAuth adds authentication headers to the request
+func (c *Client) addAuth(req *http.Request, bodyBytes []byte) {
+	// Compute the expiration time
+	expiration := time.Now().Add(signatureExpiration * time.Second).UnixMilli()
+	expirationBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(expirationBytes, uint64(expiration))
+
+	// Create the hmac
+	h := hmac.New(sha256.New, c.authKey)
+	h.Write(append(bodyBytes, expirationBytes...))
+	signature := base64.RawStdEncoding.EncodeToString(h.Sum(nil))
+
+	req.Header.Set(signatureHeader, signature)
+	req.Header.Set(expirationHeader, strconv.FormatInt(expiration, 10))
 }


### PR DESCRIPTION
### Purpose
This PR implements the symmetric auth used in wallet endpoints. Specifically this is an HMAC of the wallet body and an expiration timestamp on the signature.

### Testing
- Tested against the `GET /v0/wallet/:id` route on a locally running relayer