### PR TITLE
wallet: Implement full share serialization and new wallet derivation

### DIFF
--- a/client/api_types/api_wallet.go
+++ b/client/api_types/api_wallet.go
@@ -35,24 +35,24 @@ func (a *Amount) UnmarshalJSON(b []byte) error {
 	return a.SetString(string(b), 10)
 }
 
-// OrderSide represents the side of an order (buy or sell)
-type OrderSide uint8
+// ApiOrderSide represents the side of an order (buy or sell)
+type ApiOrderSide uint8
 
 const (
-	Buy OrderSide = iota
+	Buy ApiOrderSide = iota
 	Sell
 )
 
-// OrderType represents the type of an order (midpoint or limit)
-type OrderType uint8
+// ApiOrderType represents the type of an order (midpoint or limit)
+type ApiOrderType uint8
 
 const (
-	Midpoint OrderType = iota
+	Midpoint ApiOrderType = iota
 	Limit
 )
 
-// Order is an order in a Renegade wallet
-type Order struct {
+// ApiOrder is an order in a Renegade wallet
+type ApiOrder struct {
 	// The id of the order
 	Id uuid.UUID `json:"id"`
 	// The mint (erc20 address) of the base asset
@@ -71,8 +71,8 @@ type Order struct {
 	WorstCasePrice string `json:"worst_case_price"`
 }
 
-// Balance is a balance in a Renegade wallet
-type Balance struct {
+// ApiBalance is a balance in a Renegade wallet
+type ApiBalance struct {
 	// The mint (erc20 address) of the asset
 	Mint string `json:"mint"`
 	// The amount of the asset
@@ -83,8 +83,8 @@ type Balance struct {
 	ProtocolFeeBalance Amount `json:"protocol_fee_balance"`
 }
 
-// PublicKeychain is a public keychain in the Renegade system
-type PublicKeychain struct {
+// ApiPublicKeychain is a public keychain in the Renegade system
+type ApiPublicKeychain struct {
 	// The public root key of the wallet
 	// As a hex string
 	PkRoot string `json:"pk_root"`
@@ -94,7 +94,7 @@ type PublicKeychain struct {
 }
 
 // ApiPrivateKeychain represents a private keychain for the API wallet
-type PrivateKeychain struct {
+type ApiPrivateKeychain struct {
 	// The private root key of the wallet
 	// As a hex string, optional
 	SkRoot *string `json:"sk_root,omitempty"`
@@ -106,26 +106,26 @@ type PrivateKeychain struct {
 	SymmetricKey string `json:"symmetric_key"`
 }
 
-// Keychain represents a keychain API type that maintains all keys as hex strings
-type Keychain struct {
+// ApiKeychain represents a keychain API type that maintains all keys as hex strings
+type ApiKeychain struct {
 	// The public keychain
-	PublicKeys PublicKeychain `json:"public_keys"`
+	PublicKeys ApiPublicKeychain `json:"public_keys"`
 	// The private keychain
-	PrivateKeys PrivateKeychain `json:"private_keys"`
+	PrivateKeys ApiPrivateKeychain `json:"private_keys"`
 	// The nonce of the keychain
 	Nonce uint64 `json:"nonce"`
 }
 
-// Wallet is a wallet in the Renegade system
-type Wallet struct {
+// ApiWallet is a wallet in the Renegade system
+type ApiWallet struct {
 	// Identifier
 	Id uuid.UUID `json:"id"`
 	// The orders maintained by this wallet
-	Orders []Order `json:"orders"`
+	Orders []ApiOrder `json:"orders"`
 	// The balances maintained by the wallet to cover orders
-	Balances []Balance `json:"balances"`
+	Balances []ApiBalance `json:"balances"`
 	// The keys that authenticate wallet access
-	KeyChain Keychain `json:"key_chain"`
+	KeyChain ApiKeychain `json:"key_chain"`
 	// The managing cluster's public key
 	// The public encryption key of the cluster that may collect relayer fees
 	// on this wallet

--- a/crypto/poseidon2.go
+++ b/crypto/poseidon2.go
@@ -6,6 +6,35 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 )
 
+// PoseidonCSPRNG is a CSPRNG based on the Poseidon2 permutation
+type PoseidonCSPRNG struct {
+	state *fr.Element
+}
+
+// NewPoseidonCSPRNG creates a new PoseidonCSPRNG instance
+func NewPoseidonCSPRNG(seed fr.Element) *PoseidonCSPRNG {
+	return &PoseidonCSPRNG{
+		state: &seed,
+	}
+}
+
+// Next returns the next scalar in the CSPRNG
+func (p *PoseidonCSPRNG) Next() fr.Element {
+	hashRes := NewPoseidon2Sponge().Hash([]fr.Element{*p.state})
+	p.state = &hashRes
+	return hashRes
+}
+
+// Return the next n scalars in the CSPRNG
+func (p *PoseidonCSPRNG) NextN(n int) []fr.Element {
+	result := make([]fr.Element, n)
+	for i := 0; i < n; i++ {
+		result[i] = p.Next()
+	}
+
+	return result
+}
+
 // Poseidon2Sponge represents a sponge construction on top of the Poseidon2 permutation
 // Modeled after the implementation in:
 // https://github.com/renegade-fi/renegade/blob/main/renegade-crypto/src/hash/poseidon2.rs

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ethereum/go-ethereum v1.14.8
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/crypto v0.26.0
+	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 )
 
 require (
@@ -20,6 +20,7 @@ require (
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.26.0 h1:RrRspgV4mU+YwB4FYnuBoKsUapNIL5cohGAmSH3azsw=
 golang.org/x/crypto v0.26.0/go.mod h1:GY7jblb9wI+FOo5y8/S2oY4zWP07AkOJ4+jxCqdqn54=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
 golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
 golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/wallet/balance.go
+++ b/wallet/balance.go
@@ -1,0 +1,23 @@
+package wallet
+
+// Balance is a balance in the Renegade system
+type Balance struct {
+	// Mint is the erc20 address of the balance's asset
+	Mint Scalar
+	// Amount is the amount of the balance
+	Amount Scalar
+	// RelayerFeeBalance is the balance due to the relayer in fees
+	RelayerFeeBalance Scalar
+	// ProtocolFeeBalance is the balance due to the protocol in fees
+	ProtocolFeeBalance Scalar
+}
+
+// NewEmptyBalance creates a new balance with all zero values
+func NewEmptyBalance() Balance {
+	return Balance{
+		Mint:               Scalar{},
+		Amount:             Scalar{},
+		RelayerFeeBalance:  Scalar{},
+		ProtocolFeeBalance: Scalar{},
+	}
+}

--- a/wallet/fixed_point.go
+++ b/wallet/fixed_point.go
@@ -1,0 +1,59 @@
+package wallet
+
+import (
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+)
+
+// precisionBits is the number of bits of precision in the fixed point number
+const precisionBits = 63
+
+// FixedPoint is a fixed point number with a scalar representation
+// The scalar represents the value `floor(repr >> 2^PRECISION)`
+// For our purposes, the precision is 63 bits
+type FixedPoint struct {
+	// Repr is the integral representation of the fixed point number
+	Repr Scalar
+}
+
+// ZeroFixedPoint is the fixed point number 0
+func ZeroFixedPoint() FixedPoint {
+	return NewFixedPoint(Scalar{})
+}
+
+// NewFixedPoint creates a new fixed point number from a scalar representation
+func NewFixedPoint(repr Scalar) FixedPoint {
+	return FixedPoint{Repr: repr}
+}
+
+// FromFloat creates a new fixed point number from a float
+func FromFloat(f float64) FixedPoint {
+	bigF := big.NewFloat(f)
+	// Shift left by precisionBits
+	bigF.Mul(bigF, big.NewFloat(1<<precisionBits))
+
+	// Floor the value
+	intF, _ := bigF.Int(nil)
+
+	// Convert to Scalar
+	var elt fr.Element
+	elt.SetBigInt(intF)
+
+	return FixedPoint{Repr: Scalar(elt)}
+}
+
+// ToFloat converts a fixed point number to a float
+func (fp FixedPoint) ToFloat() float64 {
+	// Convert the repr to a bigF
+	bigF := big.NewFloat(0)
+	elt := fr.Element(fp.Repr)
+	var intF big.Int
+	bigF.SetInt(elt.BigInt(&intF))
+
+	// Shift right by precisionBits
+	bigF.Quo(bigF, big.NewFloat(1<<precisionBits))
+
+	f, _ := bigF.Float64()
+	return f
+}

--- a/wallet/fixed_point_test.go
+++ b/wallet/fixed_point_test.go
@@ -1,0 +1,26 @@
+package wallet
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+)
+
+// precisionTolerance is the maximum allowed difference between the original and
+// converted float values
+const precisionTolerance = 1e-10
+
+// TestFixedPoint tests the fixed point implementation
+func TestFixedPoint(t *testing.T) {
+	// Generate a random float64 between 0 and 1000
+	originalFloat := rand.Float64() * 1000
+
+	// Convert to and from FixedPoint
+	fixedPoint := FromFloat(originalFloat)
+	convertedFloat := fixedPoint.ToFloat()
+
+	// Check if the converted value is within tolerance of the original
+	if math.Abs(originalFloat-convertedFloat) > precisionTolerance {
+		t.Errorf("Conversion not within tolerance. Original: %f, Converted: %f", originalFloat, convertedFloat)
+	}
+}

--- a/wallet/keychain.go
+++ b/wallet/keychain.go
@@ -1,0 +1,135 @@
+package wallet
+
+import (
+	"crypto/ecdsa"
+	"errors"
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
+)
+
+// HmacKey is a symmetric key for HMAC-SHA256
+type HmacKey [32]byte
+
+// PublicSigningKey is a verification key over the secp256k1 curve
+type PublicSigningKey ecdsa.PublicKey
+
+func bigintToScalarLimbs(b big.Int) []Scalar {
+	localB := new(big.Int).Set(&b) // Create a local copy
+	scalarMod := fr.Modulus()
+	var limbs []Scalar
+	for localB.Sign() != 0 {
+		word := new(big.Int).Mod(localB, scalarMod)
+		elt := fr.Element{}
+		elt.SetBigInt(word)
+
+		limbs = append(limbs, Scalar(elt))
+		localB.Div(localB, scalarMod)
+	}
+	return limbs
+}
+
+func scalarLimbsToBigInt(limbs []Scalar) *big.Int {
+	scalarMod := fr.Modulus()
+	b := new(big.Int)
+	for i := len(limbs) - 1; i >= 0; i-- {
+		elt := fr.Element(limbs[i])
+
+		var eltBigint big.Int
+		elt.BigInt(&eltBigint)
+		b.Add(b, &eltBigint)
+
+		if i > 0 {
+			b.Mul(b, scalarMod)
+		}
+	}
+	return b
+}
+
+func (pk *PublicSigningKey) ToScalars() ([]Scalar, error) {
+	xScalars := bigintToScalarLimbs(*pk.X)
+	yScalars := bigintToScalarLimbs(*pk.Y)
+	if len(xScalars) != 2 || len(yScalars) != 2 {
+		return nil, errors.New("public key is not on the curve")
+	}
+
+	return []Scalar{xScalars[0], xScalars[1], yScalars[0], yScalars[1]}, nil
+}
+
+func (pk *PublicSigningKey) FromScalars(scalars *ScalarIterator) error {
+	xScalars := make([]Scalar, 2)
+	yScalars := make([]Scalar, 2)
+
+	for i := 0; i < 2; i++ {
+		x, err := scalars.Next()
+		if err != nil {
+			return err
+		}
+		xScalars[i] = x
+	}
+
+	for i := 0; i < 2; i++ {
+		y, err := scalars.Next()
+		if err != nil {
+			return err
+		}
+		yScalars[i] = y
+	}
+
+	pk.X = scalarLimbsToBigInt(xScalars)
+	pk.Y = scalarLimbsToBigInt(yScalars)
+	pk.Curve = secp256k1.S256()
+	return nil
+}
+
+func (pk *PublicSigningKey) NumScalars() int {
+	return 4
+}
+
+type PrivateSigningKey ecdsa.PrivateKey
+
+func (pk *PrivateSigningKey) ToScalars() ([]Scalar, error) {
+	limbs := bigintToScalarLimbs(*pk.D)
+	return limbs, nil
+}
+
+func (pk *PrivateSigningKey) FromScalars(scalars *ScalarIterator) error {
+	d, err := scalars.Next()
+	if err != nil {
+		return err
+	}
+	pk.D = scalarLimbsToBigInt([]Scalar{d})
+	return nil
+}
+
+func (pk *PrivateSigningKey) NumScalars() int {
+	return 2
+}
+
+// PrivateKeychain is a private keychain for the API wallet
+type PrivateKeychain struct {
+	SkRoot       *PrivateSigningKey
+	SkMatch      Scalar
+	SymmetricKey HmacKey
+}
+
+// PublicKeychain is a public keychain for the API wallet
+type PublicKeychain struct {
+	PkRoot  PublicSigningKey
+	PkMatch Scalar
+	Nonce   Uint64
+}
+
+// Keychain is a keychain for the API wallet
+type Keychain struct {
+	PublicKeys  PublicKeychain
+	PrivateKeys PrivateKeychain
+}
+
+// FeeEncryptionKey is a public encryption key on the Baby Jubjub curve
+// We represent the key in coordinate form with scalar values
+type FeeEncryptionKey struct {
+	X Scalar
+	Y Scalar
+}

--- a/wallet/keychain_derivation.go
+++ b/wallet/keychain_derivation.go
@@ -118,22 +118,22 @@ func DeriveWalletID(privateKey *ecdsa.PrivateKey, chainId uint64) (uuid.UUID, er
 // createKeychain creates a new keychain from the private keys
 func createKeychain(skRoot *ecdsa.PrivateKey, skMatch Scalar, symmetricKey HmacKey) *Keychain {
 	privateKeys := PrivateKeychain{
-		SkRoot:       skRoot,
+		SkRoot:       (*PrivateSigningKey)(skRoot),
 		SkMatch:      skMatch,
 		SymmetricKey: symmetricKey,
 	}
 
-	pkRoot := skRoot.PublicKey
+	pkRoot := PublicSigningKey(skRoot.PublicKey)
 	pkMatch := publicMatchKey(skMatch)
 	publicKeys := PublicKeychain{
 		PkRoot:  pkRoot,
 		PkMatch: pkMatch,
+		Nonce:   0,
 	}
 
 	return &Keychain{
 		PublicKeys:  publicKeys,
 		PrivateKeys: privateKeys,
-		Nonce:       0,
 	}
 }
 

--- a/wallet/keychain_test.go
+++ b/wallet/keychain_test.go
@@ -1,0 +1,23 @@
+package wallet
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+)
+
+func TestScalarLimbsToBigInt(t *testing.T) {
+	// Sample a random big.Int
+	limit := new(big.Int).Lsh(big.NewInt(1), 256)
+	r := rand.New(rand.NewSource(0))
+	randomBigInt := new(big.Int).Rand(r, limit)
+
+	// Convert to scalar limbs and back
+	limbs := bigintToScalarLimbs(*randomBigInt)
+	recoveredBigInt := scalarLimbsToBigInt(limbs)
+
+	// Assert equality
+	if randomBigInt.Cmp(recoveredBigInt) != 0 {
+		t.Errorf("Conversion failed: original %v, recovered %v", randomBigInt, recoveredBigInt)
+	}
+}

--- a/wallet/order.go
+++ b/wallet/order.go
@@ -1,0 +1,65 @@
+package wallet
+
+import (
+	"fmt"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+)
+
+// OrderSide is an enum for the side of an order
+type OrderSide int
+
+const (
+	Buy OrderSide = iota
+	Sell
+)
+
+func (s *OrderSide) FromScalars(scalars *ScalarIterator) error {
+	scalar, err := scalars.Next()
+	if err != nil {
+		return err
+	}
+
+	elt := fr.Element(scalar)
+	if !(elt.IsZero() || elt.IsOne()) {
+		return fmt.Errorf("invalid OrderSide value: %v", scalar)
+	}
+
+	*s = OrderSide(elt.Uint64())
+	return nil
+}
+
+func (s *OrderSide) ToScalars() ([]Scalar, error) {
+	elt := fr.NewElement(uint64(*s))
+	return []Scalar{Scalar(elt)}, nil
+}
+
+func (s *OrderSide) NumScalars() int {
+	return 1
+}
+
+// Order is an order in the Renegade system
+type Order struct {
+	// BaseMint is the erc20 address of the base asset
+	BaseMint Scalar
+	// QuoteMint is the erc20 address of the quote asset
+	QuoteMint Scalar
+	// Amount is the amount of the order
+	Amount Scalar
+	// Side is the side of the order
+	// 0 for buy, 1 for sell
+	Side Scalar
+	// WorstCasePrice is the worst case price of the order
+	WorstCasePrice FixedPoint
+}
+
+// NewEmptyOrder creates a new order with all zero values
+func NewEmptyOrder() Order {
+	return Order{
+		BaseMint:       Scalar{},
+		QuoteMint:      Scalar{},
+		Amount:         Scalar{},
+		Side:           Scalar{},
+		WorstCasePrice: FixedPoint{},
+	}
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2,62 +2,206 @@ package wallet
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/google/uuid"
+
+	renegade_crypto "renegade.fi/golang-sdk/crypto"
+)
+
+const (
+	// numScalarsWalletShare is the number of scalars in a wallet share
+	numScalarsWalletShare = 70
+	// maxBalances is the maximum number of balances in a wallet
+	maxBalances = 10
+	// maxOrders is the maximum number of orders in a wallet
+	maxOrders = 4
 )
 
 // Scalar is a scalar field element from the bn254 curve
 type Scalar fr.Element
 
-// OrderSide is an enum for the side of an order
-type OrderSide int
+// Add adds two scalars
+func (s *Scalar) Add(other Scalar) Scalar {
+	var result fr.Element
+	fr1 := fr.Element(*s)
+	fr2 := fr.Element(other)
+	result.Add(&fr1, &fr2)
 
-const (
-	Buy OrderSide = iota
-	Sell
-)
-
-// Order is an order in the Renegade system
-type Order struct {
-	BaseAsset      Scalar    `json:"base_asset"`
-	QuoteAsset     Scalar    `json:"quote_asset"`
-	Amount         Scalar    `json:"amount"`
-	Side           OrderSide `json:"side"`
-	WorstCasePrice Scalar    `json:"worst_case_price"`
+	return Scalar(result)
 }
 
-// Balance is a balance in the Renegade system
-type Balance struct {
-	Mint   Scalar `json:"mint"`
-	Amount Scalar `json:"amount"`
+// Sub subtracts two scalars
+func (s *Scalar) Sub(other Scalar) Scalar {
+	var result fr.Element
+	fr1 := fr.Element(*s)
+	fr2 := fr.Element(other)
+	result.Sub(&fr1, &fr2)
+
+	return Scalar(result)
 }
 
-// HmacKey is a symmetric key for HMAC-SHA256
-type HmacKey [32]byte
-
-// PrivateKeychain is a private keychain for the API wallet
-type PrivateKeychain struct {
-	SkRoot       *ecdsa.PrivateKey
-	SkMatch      Scalar
-	SymmetricKey HmacKey
+// WalletShare represents a secret share of a wallet, containing only the elements of a wallet that are stored on-chain
+type WalletShare struct {
+	// Balances are the balances of the wallet
+	Balances [maxBalances]Balance
+	// Orders are the orders of the wallet
+	Orders [maxOrders]Order
+	// Keys are the public keys of the wallet
+	Keys PublicKeychain
+	// MatchFee is the fee that the wallet pays to the cluster that matches its orders
+	MatchFee FixedPoint
+	// ManagingCluster is the public encryption key of the cluster that
+	// receives fees for matching orders in the wallet
+	ManagingCluster FeeEncryptionKey
+	// Blinder is the additive blinder applied to all secret shares to make an adequately determined
+	// algebraic system on the shares impossible, even when one knows the underlying value
+	Blinder Scalar
 }
 
-// PublicKeychain is a public keychain for the API wallet
-type PublicKeychain struct {
-	PkRoot  ecdsa.PublicKey
-	PkMatch Scalar
+// EmptyWalletShare creates a new wallet share with all zero values
+func EmptyWalletShare(publicKeys PublicKeychain) (WalletShare, error) {
+	// Create a slice of scalars with all zero values
+	scalars := make([]Scalar, numScalarsWalletShare)
+	for i := range scalars {
+		scalars[i] = Scalar{}
+	}
+
+	// Deserialize a wallet share from the scalars
+	share := WalletShare{}
+	err := FromScalarsRecursive(&share, NewScalarIterator(scalars))
+	if err != nil {
+		return WalletShare{}, err
+	}
+
+	share.Keys = publicKeys
+	return share, nil
 }
 
-// Keychain is a keychain for the API wallet
-type Keychain struct {
-	PublicKeys  PublicKeychain
-	PrivateKeys PrivateKeychain
-	Nonce       uint64
+// SplitIntoShares splits a wallet share into two shares using the given private shares and blinder
+func (ws *WalletShare) SplitPublicPrivate(privateShares []Scalar, blinder Scalar) (WalletShare, WalletShare, error) {
+	// Serialize the wallet share into scalars
+	scalars, err := ToScalarsRecursive(ws)
+	if err != nil {
+		return WalletShare{}, WalletShare{}, err
+	}
+
+	// The shares should be the same length as the scalars
+	if len(privateShares) != len(scalars) {
+		return WalletShare{}, WalletShare{}, fmt.Errorf("private shares and scalars have different lengths")
+	}
+
+	// Subtract the private shares from the scalars to get the public shares
+	// Then blind the public shares with the blinder
+	publicShares := make([]Scalar, len(scalars))
+	for i := range privateShares {
+		publicShares[i] = scalars[i].Sub(privateShares[i])
+		publicShares[i] = publicShares[i].Add(blinder)
+	}
+
+	// Blind the public shares additively with the blinder
+	// Deserialize the shares from the scalars
+	privateShare := WalletShare{}
+	err = FromScalarsRecursive(&privateShare, NewScalarIterator(privateShares))
+	if err != nil {
+		return WalletShare{}, WalletShare{}, err
+	}
+
+	publicShare := WalletShare{}
+	err = FromScalarsRecursive(&publicShare, NewScalarIterator(publicShares))
+	if err != nil {
+		return WalletShare{}, WalletShare{}, err
+	}
+
+	return privateShare, publicShare, nil
 }
 
 // Wallet is a wallet in the Renegade system
 type Wallet struct {
-	ID     uuid.UUID           `json:"id"`
-	Orders map[uuid.UUID]Order `json:"orders"`
+	ID                  uuid.UUID
+	Orders              []Order
+	Balances            []Balance
+	Keychain            *Keychain
+	ManagingCluster     FeeEncryptionKey
+	MatchFee            FixedPoint
+	BlindedPublicShares WalletShare
+	PrivateShares       WalletShare
+	Blinder             Scalar
+}
+
+// NewEmptyWallet creates a new empty wallet
+func NewEmptyWallet(privateKey *ecdsa.PrivateKey, chainId uint64) (*Wallet, error) {
+	walletId, err := DeriveWalletID(privateKey, chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Derive the keychain
+	keychain, err := DeriveKeychain(privateKey, chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Derive the seeds for secret shares and blinders
+	blinderSeed, shareSeed, err := DeriveWalletSeeds(privateKey, chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup a wallet with empty shares
+	emptyShare, err := EmptyWalletShare(keychain.PublicKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reblind the wallet
+	blinder, blinderPrivateShare := walletBlinderFromSeed(blinderSeed)
+	privateShareScalars := walletSharesFromStream(shareSeed)
+	privateShare, publicShare, err := emptyShare.SplitPublicPrivate(privateShareScalars, blinder)
+	if err != nil {
+		return nil, err
+	}
+
+	privateShare.Blinder = blinderPrivateShare
+	publicShare.Blinder = blinder.Sub(blinderPrivateShare)
+
+	return &Wallet{
+		ID:       walletId,
+		Orders:   make([]Order, 0),
+		Balances: make([]Balance, 0),
+		Keychain: keychain,
+		// The managing relayer will set the following two fields
+		ManagingCluster:     emptyShare.ManagingCluster,
+		MatchFee:            emptyShare.MatchFee,
+		BlindedPublicShares: publicShare,
+		PrivateShares:       privateShare,
+		Blinder:             blinder,
+	}, nil
+}
+
+// walletSharesFromStream generates numScalarsWalletShare scalars from a CSPRNG seeded with the given scalar
+func walletSharesFromStream(seed Scalar) []Scalar {
+	// Create a poseidon CSPRNG from the seed and generate numScalarsWalletShare scalars
+	csprng := renegade_crypto.NewPoseidonCSPRNG(fr.Element(seed))
+	elts := csprng.NextN(numScalarsWalletShare)
+
+	// Wrap the elements in a slice of scalars
+	scalars := make([]Scalar, len(elts))
+	for i, elt := range elts {
+		scalars[i] = Scalar(elt)
+	}
+
+	return scalars
+}
+
+// walletBlinderFromSeed generates a wallet blinder and blinder private share from a CSPRNG seeded with the given scalar
+func walletBlinderFromSeed(seed Scalar) (Scalar, Scalar) {
+	csprng := renegade_crypto.NewPoseidonCSPRNG(fr.Element(seed))
+
+	// Generate a blinder and blinder private share
+	blinder := Scalar(csprng.Next())
+	blinderPrivateShare := Scalar(csprng.Next())
+
+	return blinder, blinderPrivateShare
 }


### PR DESCRIPTION
### Purpose
This PR implements a method to derive a new, empty wallet from an Ethereum private key. This method generates the keychain and shares of the wallet then generates private shares and blinders and splits the wallet into its shares.

### Testing
- Generated a fresh wallet from a dummy key