### PR TITLE
client: api-types: Conversion to/from API wallet

### DIFF
--- a/client/api_types/api_wallet_test.go
+++ b/client/api_types/api_wallet_test.go
@@ -1,0 +1,30 @@
+package api_types
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
+	"github.com/stretchr/testify/assert"
+	"renegade.fi/golang-sdk/wallet"
+)
+
+func TestApiWalletConversion(t *testing.T) {
+	key, err := ecdsa.GenerateKey(secp256k1.S256(), rand.Reader)
+	assert.NoError(t, err)
+	originalWallet, err := wallet.NewEmptyWallet(key, 0 /* chainId */)
+	assert.NoError(t, err)
+
+	// Convert to API wallet
+	apiWallet := ApiWallet{}
+	err = apiWallet.FromWallet(originalWallet)
+	assert.NoError(t, err)
+
+	// Convert back to wallet
+	recoveredWallet, err := apiWallet.ToWallet()
+	assert.NoError(t, err)
+
+	// Check that the recovered wallet is the same as the original wallet
+	assert.Equal(t, originalWallet, recoveredWallet)
+}

--- a/client/api_types/conversion.go
+++ b/client/api_types/conversion.go
@@ -1,0 +1,33 @@
+package api_types
+
+import (
+	"math/big"
+
+	"renegade.fi/golang-sdk/wallet"
+)
+
+// scalarToUintLimbs converts a scalar to an array of uint32 limbs
+func scalarToUintLimbs(s wallet.Scalar) [secretShareLimbCount]uint32 {
+	bigint := s.ToBigInt()
+	limbs := [secretShareLimbCount]uint32{}
+	for i := 0; i < secretShareLimbCount; i++ {
+		if bigint.BitLen() > 0 {
+			limbs[i] = uint32(bigint.Uint64())
+			bigint.Rsh(bigint, 32)
+		} else {
+			break
+		}
+	}
+
+	return limbs
+}
+
+// scalarFromUintLimbs converts an array of uint32 limbs to a scalar
+func scalarFromUintLimbs(limbs [secretShareLimbCount]uint32) wallet.Scalar {
+	bigint := new(big.Int)
+	for i := secretShareLimbCount - 1; i >= 0; i-- {
+		bigint.Lsh(bigint, 32)
+		bigint.Or(bigint, big.NewInt(int64(limbs[i])))
+	}
+	return new(wallet.Scalar).FromBigInt(bigint)
+}

--- a/client/api_types/conversion_test.go
+++ b/client/api_types/conversion_test.go
@@ -1,0 +1,27 @@
+package api_types
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/stretchr/testify/assert"
+	"renegade.fi/golang-sdk/wallet"
+)
+
+func TestScalarUintLimbConversion(t *testing.T) {
+	scalar, err := wallet.RandomScalar()
+	assert.NoError(t, err)
+
+	// Convert to and from uint32 limbs
+	limbs := scalarToUintLimbs(scalar)
+	recoveredScalar := scalarFromUintLimbs(limbs)
+
+	// Assert equality
+	assert.Equal(t, scalar, recoveredScalar, "Recovered scalar should match original")
+
+	// Test with zero
+	zeroScalar := wallet.Scalar(fr.NewElement(0))
+	zeroLimbs := scalarToUintLimbs(zeroScalar)
+	recoveredZeroScalar := scalarFromUintLimbs(zeroLimbs)
+	assert.Equal(t, zeroScalar, recoveredZeroScalar, "Recovered zero scalar should match original")
+}

--- a/wallet/fixed_point.go
+++ b/wallet/fixed_point.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
@@ -28,7 +29,7 @@ func NewFixedPoint(repr Scalar) FixedPoint {
 }
 
 // FromFloat creates a new fixed point number from a float
-func FromFloat(f float64) FixedPoint {
+func FixedPointFromFloat(f float64) FixedPoint {
 	bigF := big.NewFloat(f)
 	// Shift left by precisionBits
 	bigF.Mul(bigF, big.NewFloat(1<<precisionBits))
@@ -56,4 +57,24 @@ func (fp FixedPoint) ToFloat() float64 {
 
 	f, _ := bigF.Float64()
 	return f
+}
+
+// ToDecimalString converts a fixed point number to the base10 string representation of its `repr`
+func (fp FixedPoint) ToReprDecimalString() string {
+	reprBigint := fp.Repr.ToBigInt()
+
+	// Convert to string with 10 decimal places
+	return reprBigint.Text(10 /* base */)
+}
+
+// FromReprDecimalString creates a new fixed point number from a decimal string
+func (fp *FixedPoint) FromReprDecimalString(s string) (FixedPoint, error) {
+	reprBigint, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return FixedPoint{}, fmt.Errorf("failed to convert decimal string to big.Int")
+	}
+
+	repr := new(Scalar).FromBigInt(reprBigint)
+	fp.Repr = repr
+	return *fp, nil
 }

--- a/wallet/fixed_point_test.go
+++ b/wallet/fixed_point_test.go
@@ -16,7 +16,7 @@ func TestFixedPoint(t *testing.T) {
 	originalFloat := rand.Float64() * 1000
 
 	// Convert to and from FixedPoint
-	fixedPoint := FromFloat(originalFloat)
+	fixedPoint := FixedPointFromFloat(originalFloat)
 	convertedFloat := fixedPoint.ToFloat()
 
 	// Check if the converted value is within tolerance of the original

--- a/wallet/order.go
+++ b/wallet/order.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/google/uuid"
 )
 
 // OrderSide is an enum for the side of an order
@@ -40,6 +41,8 @@ func (s *OrderSide) NumScalars() int {
 
 // Order is an order in the Renegade system
 type Order struct {
+	// ID is the id of the order
+	ID uuid.UUID `scalar_serialize:"skip"`
 	// BaseMint is the erc20 address of the base asset
 	BaseMint Scalar
 	// QuoteMint is the erc20 address of the quote asset

--- a/wallet/scalar_serialization.go
+++ b/wallet/scalar_serialization.go
@@ -93,6 +93,11 @@ func toScalarsStruct(v reflect.Value) ([]Scalar, error) {
 			continue
 		}
 
+		// Check for the scalar_serialize="skip" tag
+		if v.Type().Field(i).Tag.Get("scalar_serialize") == "skip" {
+			continue
+		}
+
 		// Convert the field to a Scalar
 		fieldScalars, err := ToScalarsRecursive(field.Addr().Interface())
 		if err != nil {
@@ -186,6 +191,12 @@ func fromScalarsStruct(v reflect.Value, scalars *ScalarIterator) error {
 		if !field.CanSet() {
 			continue
 		}
+
+		// Check for the scalar_serialize="skip" tag
+		if v.Type().Field(i).Tag.Get("scalar_serialize") == "skip" {
+			continue
+		}
+
 		if err := FromScalarsRecursive(field.Addr().Interface(), scalars); err != nil {
 			return err
 		}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1,0 +1,49 @@
+package wallet
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScalarToFromHex(t *testing.T) {
+	// Generate a random scalar
+	randomScalar, err := RandomScalar()
+	if err != nil {
+		t.Fatalf("Failed to generate random scalar: %v", err)
+	}
+
+	// Convert to hex string and back
+	hexString := randomScalar.ToHexString()
+	var newScalar Scalar
+	_, err = newScalar.FromHexString(hexString)
+	assert.NoError(t, err)
+	assert.Equal(t, randomScalar, newScalar)
+}
+
+func TestScalarToBigIntAndBack(t *testing.T) {
+	// Generate a random scalar
+	randomScalar, err := RandomScalar()
+	assert.NoError(t, err, "Failed to generate random scalar")
+
+	// Convert to and from big.Int
+	bigInt := randomScalar.ToBigInt()
+	var newScalar Scalar
+	newScalar.FromBigInt(bigInt)
+
+	// Compare the original and new scalar
+	assert.Equal(t, randomScalar, newScalar, "Scalar -> BigInt -> Scalar conversion failed")
+}
+
+func TestNewEmptyWallet(t *testing.T) {
+	// Generate a random private key
+	privateKey, err := ecdsa.GenerateKey(secp256k1.S256(), rand.Reader)
+	assert.NoError(t, err, "Failed to generate random private key")
+
+	// Create a new empty wallet and ensure it doesn't error
+	_, err = NewEmptyWallet(privateKey, 1 /* chainId */)
+	assert.NoError(t, err, "Failed to create new empty wallet")
+}


### PR DESCRIPTION
### Purpose
This PR implements type conversion to and from an API wallet. This includes renegade relayer compatible serialization of keys, shares, etc.

### Testing
- All unit tests pass
- Tested converting a runtime wallet to/from an api wallet