### PR TITLE
client: Implement `GetWallet` and `CreateWallet` tasks

### DIFF
--- a/client/api_types/api_wallet_test.go
+++ b/client/api_types/api_wallet_test.go
@@ -17,8 +17,7 @@ func TestApiWalletConversion(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Convert to API wallet
-	apiWallet := ApiWallet{}
-	err = apiWallet.FromWallet(originalWallet)
+	apiWallet, err := new(ApiWallet).FromWallet(originalWallet)
 	assert.NoError(t, err)
 
 	// Convert back to wallet

--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -1,0 +1,35 @@
+package api_types
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// GetWalletPath is the path for the GetWallet action
+	GetWalletPath = "/v0/wallet/%s"
+	// CreateWalletPath is the path for the CreateWallet action
+	CreateWalletPath = "/v0/wallet"
+)
+
+// buildGetWalletPath builds the path for the GetWallet action
+func BuildGetWalletPath(walletId uuid.UUID) string {
+	return fmt.Sprintf(GetWalletPath, walletId)
+}
+
+// GetWalletResponse is the response body for a GetWallet request
+type GetWalletResponse struct {
+	Wallet ApiWallet `json:"wallet"`
+}
+
+// CreateWalletRequest is the request body for the CreateWallet action
+type CreateWalletRequest struct {
+	Wallet ApiWallet `json:"wallet"`
+}
+
+// CreateWalletResponse is the response body for the CreateWallet action
+type CreateWalletResponse struct {
+	TaskId   uuid.UUID `json:"task_id"`
+	WalletId uuid.UUID `json:"wallet_id"`
+}

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"crypto/ecdsa"
+
+	"renegade.fi/golang-sdk/client/api_types"
+	"renegade.fi/golang-sdk/wallet"
+)
+
+const (
+	arbitrumChainId = 42161
+)
+
+// Client represents a client for the renegade API
+type RenegadeClient struct {
+	httpClient *HttpClient
+}
+
+// NewRenegadeClient creates a new Client with the given base URL and auth key
+func NewRenegadeClient(baseURL string, authKey *wallet.HmacKey) *RenegadeClient {
+	return &RenegadeClient{
+		httpClient: NewHttpClient(baseURL, authKey),
+	}
+}
+
+// GetWallet retrieves a wallet from the relayer.
+//
+// Parameters:
+//   - ethKey: *ecdsa.PrivateKey - The Ethereum private key associated with the wallet.
+//   - chainId: uint64 - The chain ID of the network.
+//
+// Returns:
+//   - *api_types.ApiWallet: The retrieved wallet, if successful.
+//   - error: An error if the retrieval fails, nil otherwise.
+//
+// The method first derives the wallet ID using the provided Ethereum key and chain ID.
+// It then constructs the API path and sends a GET request to the relayer.
+// If successful, it returns the wallet data in the ApiWallet format.
+func (c *RenegadeClient) GetWallet(ethKey *ecdsa.PrivateKey, chainId uint64) (*api_types.ApiWallet, error) {
+	walletId, err := wallet.DeriveWalletID(ethKey, chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	path := api_types.BuildGetWalletPath(walletId)
+	resp := api_types.GetWalletResponse{}
+	err = c.httpClient.GetWithAuth(path, nil /* body */, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.Wallet, nil
+}
+
+// CreateWallet creates a new wallet derived with provided Ethereum private key.
+//
+// Parameters:
+//   - ethKey: The Ethereum private key used to create and control the wallet
+//
+// Returns:
+//   - *api_types.CreateWalletResponse: Contains the task ID and wallet ID of the created wallet
+//   - error: An error if the wallet creation fails, nil otherwise
+//
+// The method generates a new Renegade wallet associated with the given Ethereum key,
+// submits a creation request to the Renegade API, and returns the response.
+// This wallet can be used for private transactions within the Renegade network.
+func (c *RenegadeClient) CreateWallet(ethKey *ecdsa.PrivateKey) (*api_types.CreateWalletResponse, error) {
+	return c.CreateWalletWithChainId(ethKey, arbitrumChainId)
+}
+
+func (c *RenegadeClient) CreateWalletWithChainId(ethKey *ecdsa.PrivateKey, chainId uint64) (*api_types.CreateWalletResponse, error) {
+	// Create a new empty wallet from the base key
+	newWallet, err := wallet.NewEmptyWallet(ethKey, chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	apiWallet, err := new(api_types.ApiWallet).FromWallet(newWallet)
+	if err != nil {
+		return nil, err
+	}
+
+	// Post the wallet to the relayer
+	request := api_types.CreateWalletRequest{
+		Wallet: *apiWallet,
+	}
+	resp := api_types.CreateWalletResponse{}
+	err = c.httpClient.PostWithAuth(api_types.CreateWalletPath, request, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}

--- a/wallet/keychain_derivation.go
+++ b/wallet/keychain_derivation.go
@@ -250,7 +250,6 @@ func getExtendedSigBytes(message []byte, pkey *ecdsa.PrivateKey) ([]byte, error)
 // We use this method to reduce into a 256 bit field with sufficient entropy
 func extendTo64Bytes(b []byte) ([]byte, error) {
 	if len(b) != 32 {
-		fmt.Println("n_bytes", len(b))
 		return nil, fmt.Errorf("extendTo64Bytes: input must be 32 bytes")
 	}
 

--- a/wallet/scalar_serialization_test.go
+++ b/wallet/scalar_serialization_test.go
@@ -22,6 +22,7 @@ type TestStruct struct {
 
 func randomScalar() Scalar {
 	elt := fr.Element{}
+	// nolint: errcheck
 	elt.SetRandom()
 	return Scalar(elt)
 }


### PR DESCRIPTION
### Purpose
This PR implements methods to fetch a wallet and create a new wallet with a connected relayer. The structure of the client and the dependencies it holds are still being fleshed out.

### Testing
- Tested creating a new wallet and fetching it from a local relayer