### PR TITLE
client: Implement wallet refreshes

### DIFF
--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -11,6 +11,8 @@ const (
 	GetWalletPath = "/v0/wallet/%s"
 	// LookupWalletPath is the path for the LookupWallet action
 	LookupWalletPath = "/v0/wallet/lookup"
+	// RefreshWalletPath is the path for the RefreshWallet action
+	RefreshWalletPath = "/v0/wallet/%s/refresh"
 	// CreateWalletPath is the path for the CreateWallet action
 	CreateWalletPath = "/v0/wallet"
 )
@@ -20,6 +22,11 @@ type ScalarLimbs [secretShareLimbCount]uint32
 // buildGetWalletPath builds the path for the GetWallet action
 func BuildGetWalletPath(walletId uuid.UUID) string {
 	return fmt.Sprintf(GetWalletPath, walletId)
+}
+
+// buildRefreshWalletPath builds the path for the RefreshWallet action
+func BuildRefreshWalletPath(walletId uuid.UUID) string {
+	return fmt.Sprintf(RefreshWalletPath, walletId)
 }
 
 // GetWalletResponse is the response body for a GetWallet request
@@ -39,6 +46,11 @@ type LookupWalletRequest struct {
 type LookupWalletResponse struct {
 	WalletId uuid.UUID `json:"wallet_id"`
 	TaskId   uuid.UUID `json:"task_id"`
+}
+
+// RefreshWalletResponse is the response body for a RefreshWallet request
+type RefreshWalletResponse struct {
+	TaskId uuid.UUID `json:"task_id"`
 }
 
 // CreateWalletRequest is the request body for the CreateWallet action

--- a/client/client.go
+++ b/client/client.go
@@ -43,17 +43,13 @@ func NewRenegadeClientWithChainId(baseURL string, ethKey *ecdsa.PrivateKey, chai
 
 // GetWallet retrieves a wallet from the relayer.
 //
-// Parameters:
-//   - ethKey: *ecdsa.PrivateKey - The Ethereum private key associated with the wallet.
-//   - chainId: uint64 - The chain ID of the network.
-//
 // Returns:
 //   - *api_types.ApiWallet: The retrieved wallet, if successful.
 //   - error: An error if the retrieval fails, nil otherwise.
 //
-// The method first derives the wallet ID using the provided Ethereum key and chain ID.
-// It then constructs the API path and sends a GET request to the relayer.
-// If successful, it returns the wallet data in the ApiWallet format.
+// The method uses the client's wallet secrets to construct the API path
+// and sends a GET request to the relayer. If successful, it returns the
+// wallet data in the ApiWallet format.
 func (c *RenegadeClient) GetWallet() (*api_types.ApiWallet, error) {
 	walletId := c.walletSecrets.Id
 	path := api_types.BuildGetWalletPath(walletId)
@@ -98,16 +94,39 @@ func (c *RenegadeClient) LookupWallet() (*api_types.LookupWalletResponse, error)
 	return &resp, nil
 }
 
-// CreateWallet creates a new wallet derived with provided Ethereum private key.
+// RefreshWallet refreshes the relayer's view of the wallet's state by looking up the wallet on-chain.
 //
-// Parameters:
-//   - ethKey: The Ethereum private key used to create and control the wallet
+// This method sends a request to the relayer to update its local state with the latest on-chain
+// information for the wallet associated with the client. It's useful for synchronizing the
+// relayer's view with the current blockchain state, especially after on-chain transactions.
+//
+// Returns:
+//   - *api_types.RefreshWalletResponse: Contains the task ID for the refresh operation.
+//   - error: An error if the refresh operation fails, nil otherwise.
+//
+// The method uses the client's wallet ID to construct the API path and sends a POST request
+// to the relayer. If successful, it returns the response containing the task ID for tracking
+// the refresh operation.
+func (c *RenegadeClient) RefreshWallet() (*api_types.RefreshWalletResponse, error) {
+	walletId := c.walletSecrets.Id
+	path := api_types.BuildRefreshWalletPath(walletId)
+
+	resp := api_types.RefreshWalletResponse{}
+	err := c.httpClient.PostWithAuth(path, nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// CreateWallet creates a new wallet derived from the client's wallet secrets.
 //
 // Returns:
 //   - *api_types.CreateWalletResponse: Contains the task ID and wallet ID of the created wallet
 //   - error: An error if the wallet creation fails, nil otherwise
 //
-// The method generates a new Renegade wallet associated with the given Ethereum key,
+// The method generates a new Renegade wallet using the client's wallet secrets,
 // submits a creation request to the Renegade API, and returns the response.
 // This wallet can be used for private transactions within the Renegade network.
 func (c *RenegadeClient) CreateWallet() (*api_types.CreateWalletResponse, error) {

--- a/wallet/scalar_serialization_test.go
+++ b/wallet/scalar_serialization_test.go
@@ -17,7 +17,6 @@ type TestStruct struct {
 	Uint64Field  Uint64
 	NestedStruct TestNestedStruct
 	ArrayField   [2]Scalar
-	SliceField   []Scalar
 }
 
 func randomScalar() Scalar {
@@ -66,24 +65,6 @@ func TestToFromScalarsArray(t *testing.T) {
 	assert.Equal(t, original, reconstructed)
 }
 
-func TestToFromScalarsSlice(t *testing.T) {
-	// Create a slice of random scalars
-	original := []Scalar{randomScalar(), randomScalar(), randomScalar()}
-
-	// Serialize to scalars
-	scalars, err := ToScalarsRecursive(&original)
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(scalars))
-
-	// Deserialize from scalars
-	var reconstructed []Scalar
-	err = FromScalarsRecursive(&reconstructed, NewScalarIterator(scalars))
-	assert.NoError(t, err)
-
-	// Compare original and reconstructed
-	assert.Equal(t, original, reconstructed)
-}
-
 func TestToFromScalarsStruct(t *testing.T) {
 	original := TestNestedStruct{
 		NestedScalar: randomScalar(),
@@ -110,13 +91,12 @@ func TestToFromScalarsNestedStruct(t *testing.T) {
 		Uint64Field:  Uint64(1),
 		NestedStruct: TestNestedStruct{NestedScalar: randomScalar(), NestedUint64: Uint64(2)},
 		ArrayField:   [2]Scalar{randomScalar(), randomScalar()},
-		SliceField:   []Scalar{randomScalar(), randomScalar(), randomScalar()},
 	}
 
 	// Serialize to scalars
 	scalars, err := ToScalarsRecursive(&original)
 	assert.NoError(t, err)
-	assert.Equal(t, 9, len(scalars))
+	assert.Equal(t, 6, len(scalars))
 
 	// Deserialize from scalars
 	var reconstructed TestStruct


### PR DESCRIPTION
### Purpose
This PR implements wallet refreshes in the `RenegadeClient` and removes a buggy unit test

### Testing
- All tests pass
- Tested refreshes against a locally running relayer