### PR TITLE
client: Implement order placement

### DIFF
--- a/client/api_types/api_wallet.go
+++ b/client/api_types/api_wallet.go
@@ -80,25 +80,25 @@ type ApiOrder struct {
 }
 
 // FromOrder converts a wallet.Order to an ApiOrder
-func (a *ApiOrder) FromOrder(o *wallet.Order) error {
-	a.Id = o.ID
+func (a *ApiOrder) FromOrder(o *wallet.Order) (*ApiOrder, error) {
+	a.Id = o.Id
 	a.BaseMint = o.BaseMint.ToHexString()
 	a.QuoteMint = o.QuoteMint.ToHexString()
 	a.Amount = Amount(*o.Amount.ToBigInt())
 	side, err := orderSideFromScalar(o.Side)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	a.Side = side
 	a.WorstCasePrice = o.WorstCasePrice.ToReprDecimalString()
 
-	return nil
+	return a, nil
 }
 
 // ToOrder converts an ApiOrder to a wallet.Order
 func (a *ApiOrder) ToOrder(o *wallet.Order) error {
-	o.ID = a.Id
+	o.Id = a.Id
 	if _, err := o.BaseMint.FromHexString(a.BaseMint); err != nil {
 		return err
 	}
@@ -305,7 +305,7 @@ func (a *ApiWallet) FromWallet(w *wallet.Wallet) (*ApiWallet, error) {
 	a.Orders = make([]ApiOrder, len(w.Orders))
 	for _, order := range w.Orders {
 		var apiOrder ApiOrder
-		if err := apiOrder.FromOrder(&order); err != nil {
+		if _, err := apiOrder.FromOrder(&order); err != nil {
 			return nil, err
 		}
 		a.Orders = append(a.Orders, apiOrder)

--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -9,24 +9,46 @@ import (
 const (
 	// GetWalletPath is the path for the GetWallet action
 	GetWalletPath = "/v0/wallet/%s"
+	// BackOfQueueWalletPath is the path to fetch the wallet after all tasks in its queue have been processed
+	BackOfQueueWalletPath = "/v0/wallet/%s/back_of_queue"
 	// LookupWalletPath is the path for the LookupWallet action
 	LookupWalletPath = "/v0/wallet/lookup"
 	// RefreshWalletPath is the path for the RefreshWallet action
 	RefreshWalletPath = "/v0/wallet/%s/refresh"
 	// CreateWalletPath is the path for the CreateWallet action
 	CreateWalletPath = "/v0/wallet"
+	// CreateOrderPath is the path for the CreateOrder action
+	CreateOrderPath = "/v0/wallet/%s/orders"
 )
 
 type ScalarLimbs [secretShareLimbCount]uint32
+
+// WalletUpdateAuthorization encapsulates the client generated authorization for wallet updates
+type WalletUpdateAuthorization struct {
+	// StatementSig is the signature of the commitment to the new wallet under the client's current root key
+	StatementSig []byte `json:"statement_sig"`
+	// NewRootKey is the root key for the new wallet, if the client prefers to rotate the root key
+	NewRootKey *string `json:"new_root_key"`
+}
 
 // buildGetWalletPath builds the path for the GetWallet action
 func BuildGetWalletPath(walletId uuid.UUID) string {
 	return fmt.Sprintf(GetWalletPath, walletId)
 }
 
+// buildBackOfQueueWalletPath builds the path for the BackOfQueueWallet action
+func BuildBackOfQueueWalletPath(walletId uuid.UUID) string {
+	return fmt.Sprintf(BackOfQueueWalletPath, walletId)
+}
+
 // buildRefreshWalletPath builds the path for the RefreshWallet action
 func BuildRefreshWalletPath(walletId uuid.UUID) string {
 	return fmt.Sprintf(RefreshWalletPath, walletId)
+}
+
+// buildCreateOrderPath builds the path for the CreateOrder action
+func BuildCreateOrderPath(walletId uuid.UUID) string {
+	return fmt.Sprintf(CreateOrderPath, walletId)
 }
 
 // GetWalletResponse is the response body for a GetWallet request
@@ -62,4 +84,18 @@ type CreateWalletRequest struct {
 type CreateWalletResponse struct {
 	TaskId   uuid.UUID `json:"task_id"`
 	WalletId uuid.UUID `json:"wallet_id"`
+}
+
+// CreateOrderRequest is the request body for the CreateOrder action
+type CreateOrderRequest struct {
+	Order ApiOrder `json:"order"`
+	WalletUpdateAuthorization
+}
+
+// CreateOrderResponse is the response body for the CreateOrder action
+type CreateOrderResponse struct {
+	// Id is the ID of the order that was created
+	Id uuid.UUID `json:"id"`
+	// TaskId is the ID of the task that was created to update the wallet
+	TaskId uuid.UUID `json:"task_id"`
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/ethereum/go-ethereum v1.14.8
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.26.0 h1:RrRspgV4mU+YwB4FYnuBoKsUapNIL5cohGAmSH3azsw=
 golang.org/x/crypto v0.26.0/go.mod h1:GY7jblb9wI+FOo5y8/S2oY4zWP07AkOJ4+jxCqdqn54=
-golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
-golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
 golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
 golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/wallet/balance.go
+++ b/wallet/balance.go
@@ -21,3 +21,8 @@ func NewEmptyBalance() Balance {
 		ProtocolFeeBalance: Scalar{},
 	}
 }
+
+// IsZero returns true if the balance amount and fees are zero
+func (b *Balance) IsZero() bool {
+	return b.Amount.IsZero() && b.RelayerFeeBalance.IsZero() && b.ProtocolFeeBalance.IsZero()
+}

--- a/wallet/helpers.go
+++ b/wallet/helpers.go
@@ -1,0 +1,18 @@
+package wallet
+
+import (
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	renegade_crypto "renegade.fi/golang-sdk/crypto"
+)
+
+// HashScalars hashes a slice of scalars using Poseidon2
+func HashScalars(scalars []Scalar) Scalar {
+	sponge := renegade_crypto.NewPoseidon2Sponge()
+	elts := make([]fr.Element, len(scalars))
+	for i, scalar := range scalars {
+		elts[i] = fr.Element(scalar)
+	}
+
+	res := sponge.Hash(elts)
+	return Scalar(res)
+}

--- a/wallet/keychain.go
+++ b/wallet/keychain.go
@@ -192,6 +192,11 @@ type Keychain struct {
 	PrivateKeys PrivateKeychain
 }
 
+// SkRoot returns the private root key
+func (k *Keychain) SkRoot() *PrivateSigningKey {
+	return k.PrivateKeys.SkRoot
+}
+
 // FeeEncryptionKey is a public encryption key on the Baby Jubjub curve
 // We represent the key in coordinate form with scalar values
 type FeeEncryptionKey struct {

--- a/wallet/order.go
+++ b/wallet/order.go
@@ -42,7 +42,7 @@ func (s *OrderSide) NumScalars() int {
 // Order is an order in the Renegade system
 type Order struct {
 	// ID is the id of the order
-	ID uuid.UUID `scalar_serialize:"skip"`
+	Id uuid.UUID `scalar_serialize:"skip"`
 	// BaseMint is the erc20 address of the base asset
 	BaseMint Scalar
 	// QuoteMint is the erc20 address of the quote asset
@@ -65,4 +65,9 @@ func NewEmptyOrder() Order {
 		Side:           Scalar{},
 		WorstCasePrice: FixedPoint{},
 	}
+}
+
+// IsZero returns whether the volume of the order is zero
+func (o *Order) IsZero() bool {
+	return o.Amount.IsZero()
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -47,3 +47,52 @@ func TestNewEmptyWallet(t *testing.T) {
 	_, err = NewEmptyWallet(privateKey, 1 /* chainId */)
 	assert.NoError(t, err, "Failed to create new empty wallet")
 }
+
+func TestWalletReblind(t *testing.T) {
+	// Generate a random private key
+	privateKey, err := ecdsa.GenerateKey(secp256k1.S256(), rand.Reader)
+	assert.NoError(t, err, "Failed to generate random private key")
+
+	// Create a new empty wallet
+	wallet, err := NewEmptyWallet(privateKey, 1 /* chainId */)
+	assert.NoError(t, err, "Failed to create new empty wallet")
+
+	// Add a balance
+	balance := Balance{
+		Mint:               Scalar{1},
+		Amount:             Scalar{2},
+		RelayerFeeBalance:  Scalar{3},
+		ProtocolFeeBalance: Scalar{4},
+	}
+	err = wallet.AddBalance(balance)
+	assert.NoError(t, err, "Failed to add new balance")
+
+	// Add an order
+	order := Order{
+		BaseMint:       Scalar{2},
+		QuoteMint:      Scalar{3},
+		Amount:         Scalar{4},
+		Side:           Scalar{0}, // Buy
+		WorstCasePrice: FixedPoint{Repr: Scalar{0}},
+	}
+	err = wallet.NewOrder(order)
+	assert.NoError(t, err, "Failed to add new order")
+
+	// Reblind the wallet
+	err = wallet.Reblind()
+	assert.NoError(t, err, "Failed to reblind wallet")
+
+	// Combine the public and private shares
+	walletShare, err := CombineShares(wallet.BlindedPublicShares, wallet.PrivateShares, wallet.Blinder)
+	assert.NoError(t, err, "Failed to get existing wallet share")
+
+	// Check if the balance is correctly represented
+	assert.Equal(t, balance, walletShare.Balances[0], "Balance not correctly represented after reblinding")
+
+	// Check if the order is correctly represented
+	assert.Equal(t, order.BaseMint, walletShare.Orders[0].BaseMint, "Order BaseMint not correctly represented after reblinding")
+	assert.Equal(t, order.QuoteMint, walletShare.Orders[0].QuoteMint, "Order QuoteMint not correctly represented after reblinding")
+	assert.Equal(t, order.Amount, walletShare.Orders[0].Amount, "Order Amount not correctly represented after reblinding")
+	assert.Equal(t, order.Side, walletShare.Orders[0].Side, "Order Side not correctly represented after reblinding")
+	assert.Equal(t, order.WorstCasePrice, walletShare.Orders[0].WorstCasePrice, "Order WorstCasePrice not correctly represented after reblinding")
+}


### PR DESCRIPTION
### Purpose
This PR implements order placement in the `RenegadeClient` along with the cryptoprimitives needed to support it:
- Wallet update signatures
- Wallet commitments
- Share arithmetic and reblinds

### Testing
- Placed an order
- All unit tests pass