### PR TITLE
client, wallet: Fix various serialization incompatibilities with relayer

### DIFF
--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -10,7 +10,7 @@ const (
 	// GetWalletPath is the path for the GetWallet action
 	GetWalletPath = "/v0/wallet/%s"
 	// BackOfQueueWalletPath is the path to fetch the wallet after all tasks in its queue have been processed
-	BackOfQueueWalletPath = "/v0/wallet/%s/back_of_queue"
+	BackOfQueueWalletPath = "/v0/wallet/%s/back-of-queue"
 	// LookupWalletPath is the path for the LookupWallet action
 	LookupWalletPath = "/v0/wallet/lookup"
 	// RefreshWalletPath is the path for the RefreshWallet action
@@ -26,7 +26,7 @@ type ScalarLimbs [secretShareLimbCount]uint32
 // WalletUpdateAuthorization encapsulates the client generated authorization for wallet updates
 type WalletUpdateAuthorization struct {
 	// StatementSig is the signature of the commitment to the new wallet under the client's current root key
-	StatementSig []byte `json:"statement_sig"`
+	StatementSig *string `json:"statement_sig"`
 	// NewRootKey is the root key for the new wallet, if the client prefers to rotate the root key
 	NewRootKey *string `json:"new_root_key"`
 }

--- a/wallet/keychain.go
+++ b/wallet/keychain.go
@@ -20,6 +20,7 @@ func (k *HmacKey) ToHexString() string {
 
 // FromHexString converts a hex string to an HMAC key
 func (k *HmacKey) FromHexString(hexString string) (HmacKey, error) {
+	hexString = preprocessHexString(hexString)
 	bytes, err := hex.DecodeString(hexString)
 	if err != nil {
 		return HmacKey{}, err
@@ -124,6 +125,7 @@ func (pk *PublicSigningKey) ToHexString() string {
 
 // FromHexString converts a hex string to a public key
 func (pk *PublicSigningKey) FromHexString(hexString string) (PublicSigningKey, error) {
+	hexString = preprocessHexString(hexString)
 	bytes, err := hex.DecodeString(hexString)
 	if err != nil {
 		return PublicSigningKey{}, err
@@ -163,6 +165,7 @@ func (pk *PrivateSigningKey) ToHexString() string {
 
 // FromHexString converts a hex string to a private key
 func (pk *PrivateSigningKey) FromHexString(hexString string) (PrivateSigningKey, error) {
+	hexString = preprocessHexString(hexString)
 	bytes, err := hex.DecodeString(hexString)
 	if err != nil {
 		return PrivateSigningKey{}, err
@@ -206,7 +209,7 @@ type FeeEncryptionKey struct {
 
 // ToBytes converts the fee encryption key to a byte slice
 func (pk *FeeEncryptionKey) ToBytes() []byte {
-	xBytes, yBytes := pk.X.Bytes(), pk.Y.Bytes()
+	xBytes, yBytes := pk.X.LittleEndianBytes(), pk.Y.LittleEndianBytes()
 	return append(xBytes[:], yBytes[:]...)
 }
 
@@ -220,8 +223,8 @@ func (pk *FeeEncryptionKey) FromBytes(bytes []byte) error {
 	var yBytes [fr.Bytes]byte
 	copy(xBytes[:], bytes[:fr.Bytes])
 	copy(yBytes[:], bytes[fr.Bytes:])
-	pk.X.FromBytes(xBytes)
-	pk.Y.FromBytes(yBytes)
+	pk.X.FromLittleEndianBytes(xBytes)
+	pk.Y.FromLittleEndianBytes(yBytes)
 	return nil
 }
 
@@ -232,6 +235,7 @@ func (pk *FeeEncryptionKey) ToHexString() string {
 
 // FromHexString converts a hex string to a fee encryption key
 func (pk *FeeEncryptionKey) FromHexString(hexString string) error {
+	hexString = preprocessHexString(hexString)
 	bytes, err := hex.DecodeString(hexString)
 	if err != nil {
 		return err

--- a/wallet/order.go
+++ b/wallet/order.go
@@ -43,15 +43,15 @@ func (s *OrderSide) NumScalars() int {
 type Order struct {
 	// ID is the id of the order
 	Id uuid.UUID `scalar_serialize:"skip"`
-	// BaseMint is the erc20 address of the base asset
-	BaseMint Scalar
 	// QuoteMint is the erc20 address of the quote asset
 	QuoteMint Scalar
-	// Amount is the amount of the order
-	Amount Scalar
+	// BaseMint is the erc20 address of the base asset
+	BaseMint Scalar
 	// Side is the side of the order
 	// 0 for buy, 1 for sell
 	Side Scalar
+	// Amount is the amount of the order
+	Amount Scalar
 	// WorstCasePrice is the worst case price of the order
 	WorstCasePrice FixedPoint
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -38,6 +38,20 @@ func TestScalarToBigIntAndBack(t *testing.T) {
 	assert.Equal(t, randomScalar, newScalar, "Scalar -> BigInt -> Scalar conversion failed")
 }
 
+func TestScalarToFromLittleEndianBytes(t *testing.T) {
+	// Generate a random scalar
+	randomScalar, err := RandomScalar()
+	assert.NoError(t, err, "Failed to generate random scalar")
+
+	// Convert to little-endian bytes and back
+	littleEndianBytes := randomScalar.LittleEndianBytes()
+	var newScalar Scalar
+	newScalar.FromLittleEndianBytes(littleEndianBytes)
+
+	// Compare the original and new scalar
+	assert.Equal(t, randomScalar, newScalar, "Scalar -> LittleEndianBytes -> Scalar conversion failed")
+}
+
 func TestNewEmptyWallet(t *testing.T) {
 	// Generate a random private key
 	privateKey, err := ecdsa.GenerateKey(secp256k1.S256(), rand.Reader)


### PR DESCRIPTION
### Purpose
This PR fixes a few serialization bugs in the golang client that made it incompatible with relayer serialization + share serialization. Update wallet signatures now work consistently.

### Testing
- Unit tests pass
- Tested placing multiple different orders with reblinds