### PR TITLE
client: renegade-client: Add `PayFees` method

### DIFF
--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -25,6 +25,8 @@ const (
 	DepositPath = "/v0/wallet/%s/balances/deposit"
 	// WithdrawPath is the path for the Withdraw action
 	WithdrawPath = "/v0/wallet/%s/balances/%s/withdraw"
+	// PayFeesPath is the path to enqueue tasks to pay wallet fees
+	PayFeesPath = "/v0/wallet/%s/pay-fees"
 	// TaskHistoryPath is the path to fetch the task history for a wallet
 	TaskHistoryPath = "/v0/wallet/%s/task-history"
 )
@@ -72,6 +74,11 @@ func BuildDepositPath(walletId uuid.UUID) string {
 // BuildWithdrawPath builds the path for the Withdraw action
 func BuildWithdrawPath(walletId uuid.UUID, mint string) string {
 	return fmt.Sprintf(WithdrawPath, walletId, mint)
+}
+
+// BuildPayFeesPath builds the path for the PayFees action
+func BuildPayFeesPath(walletId uuid.UUID) string {
+	return fmt.Sprintf(PayFeesPath, walletId)
 }
 
 // BuildTaskHistoryPath builds the path for the TaskHistory action
@@ -183,6 +190,12 @@ type WithdrawRequest struct {
 type WithdrawResponse struct {
 	// TaskId is the ID of the task that was created to update the wallet
 	TaskId uuid.UUID `json:"task_id"`
+}
+
+// PayFeesResponse is the response body for the PayFees action
+type PayFeesResponse struct {
+	// TaskIds are the IDs of the tasks that were created to pay the fees
+	TaskIds []uuid.UUID `json:"task_ids"`
 }
 
 // ApiHistoricalTask represents a historical task

--- a/client/renegade_client/balance_operations.go
+++ b/client/renegade_client/balance_operations.go
@@ -155,6 +155,18 @@ func (c *RenegadeClient) withdrawToAddress(mint string, amount *big.Int, destina
 	return nil
 }
 
+// payFees pays the fees for the wallet
+func (c *RenegadeClient) payFees() error {
+	path := api_types.BuildPayFeesPath(c.walletSecrets.Id)
+	resp := api_types.PayFeesResponse{}
+	err := c.httpClient.PostWithAuth(path, nil /* body */, &resp)
+	if err != nil {
+		return fmt.Errorf("failed to pay fees: %w", err)
+	}
+
+	return nil
+}
+
 // --- Helpers --- //
 
 // approvePermit2Deposit approves the Permit2 contract to spend the deposited amount

--- a/client/renegade_client/client.go
+++ b/client/renegade_client/client.go
@@ -215,6 +215,15 @@ func (c *RenegadeClient) WithdrawToAddress(mint string, amount *big.Int, destina
 	return c.GetWallet()
 }
 
+// PayFees pays the fees for the wallet
+func (c *RenegadeClient) PayFees() (*wallet.Wallet, error) {
+	if err := c.payFees(); err != nil {
+		return nil, err
+	}
+
+	return c.getBackOfQueueWallet()
+}
+
 // PlaceOrder creates an order on the Renegade API.
 //
 // This method sends a request to the Renegade API to create an order for a specified


### PR DESCRIPTION
### Purpose
This PR adds the pay fees method to the relayer client.

### Testing
- Matched on a local relayer then verified that the pay fees method correctly paid all fees in the relayer