### PR TITLE
client: renegade-client: Add check-wallet method

### DIFF
--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -27,6 +27,8 @@ const (
 	WithdrawPath = "/v0/wallet/%s/balances/%s/withdraw"
 	// PayFeesPath is the path to enqueue tasks to pay wallet fees
 	PayFeesPath = "/v0/wallet/%s/pay-fees"
+	// TaskStatusPath is the path to fetch the status of a task
+	TaskStatusPath = "/v0/tasks/%s"
 	// TaskHistoryPath is the path to fetch the task history for a wallet
 	TaskHistoryPath = "/v0/wallet/%s/task-history"
 )
@@ -79,6 +81,11 @@ func BuildWithdrawPath(walletId uuid.UUID, mint string) string {
 // BuildPayFeesPath builds the path for the PayFees action
 func BuildPayFeesPath(walletId uuid.UUID) string {
 	return fmt.Sprintf(PayFeesPath, walletId)
+}
+
+// BuildTaskStatusPath builds the path for the TaskStatus action
+func BuildTaskStatusPath(taskId uuid.UUID) string {
+	return fmt.Sprintf(TaskStatusPath, taskId)
 }
 
 // BuildTaskHistoryPath builds the path for the TaskHistory action
@@ -196,6 +203,25 @@ type WithdrawResponse struct {
 type PayFeesResponse struct {
 	// TaskIds are the IDs of the tasks that were created to pay the fees
 	TaskIds []uuid.UUID `json:"task_ids"`
+}
+
+// ApiTaskStatus is the status of a running task
+// ApiTaskStatus represents the status of a task
+type ApiTaskStatus struct {
+	// ID is the identifier of the task
+	ID uuid.UUID `json:"id"`
+	// Description is the description of the task
+	Description string `json:"description"`
+	// State is the current state of the task
+	State string `json:"state"`
+	// Committed indicates whether the task has already committed
+	Committed bool `json:"committed"`
+}
+
+// TaskResponse is the response body for the Task endpoint
+type TaskResponse struct {
+	// Status is the current status of the task
+	Status ApiTaskStatus `json:"status"`
 }
 
 // ApiHistoricalTask represents a historical task

--- a/client/renegade_client/wallet_operations.go
+++ b/client/renegade_client/wallet_operations.go
@@ -92,7 +92,7 @@ func (c *RenegadeClient) lookupWallet(blocking bool) error {
 	// If blocking, wait for the task to complete
 	if blocking {
 		// Wait for the task to complete
-		if err := c.waitForTask(resp.TaskId); err != nil {
+		if err := c.waitForTaskDirect(resp.TaskId); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
### Purpose
This PR adds the `CheckWallet` method to the `RenegadeClient` type. This allows a user of the sdk to check that their wallet has been indexed. It:
1. Tries to fetch the wallet from the relayer. If that fails, the method:
2. Enqueues a lookup wallet task for the wallet with the relayer

### Testing
- Tested both cases in the check path
- All tests pass