### PR TITLE
client: http: Update client to use new authentication scheme

### DIFF
--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -119,7 +119,8 @@ type RefreshWalletResponse struct {
 
 // CreateWalletRequest is the request body for the CreateWallet action
 type CreateWalletRequest struct {
-	Wallet ApiWallet `json:"wallet"`
+	Wallet      ApiWallet   `json:"wallet"`
+	BlinderSeed ScalarLimbs `json:"blinder_seed"`
 }
 
 // CreateWalletResponse is the response body for the CreateWallet action

--- a/client/renegade_client/wallet_operations.go
+++ b/client/renegade_client/wallet_operations.go
@@ -158,8 +158,10 @@ func (c *RenegadeClient) createWallet(blocking bool) error {
 	apiWallet.KeyChain.PrivateKeys.SkRoot = nil
 
 	// Post the wallet to the relayer
+	blinderSeed := api_types.ScalarToUintLimbs(c.walletSecrets.BlinderSeed)
 	request := api_types.CreateWalletRequest{
-		Wallet: *apiWallet,
+		Wallet:      *apiWallet,
+		BlinderSeed: blinderSeed,
 	}
 	resp := api_types.CreateWalletResponse{}
 	err = c.httpClient.PostWithAuth(api_types.CreateWalletPath, request, &resp)


### PR DESCRIPTION
### Purpose
This PR updates the golang client to use the new HTTP authentication scheme. I also updated the `NewWallet` request type to include the blinder seed.

### Testing
- Tested both GET and POST methods that require auth through the client.