### PR TITLE
client: external-match-client: Use geth return types and add README example

### DIFF
--- a/client/api_types/api_external_match.go
+++ b/client/api_types/api_external_match.go
@@ -18,10 +18,10 @@ type ApiExternalOrder struct {
 	MinFillSize Amount `json:"min_fill_size"`
 }
 
-// ExternalMatchBundle contains a match and a transaction that the client can submit on-chain
-type ExternalMatchBundle struct {
-	MatchResult  ApiExternalMatchResult `json:"match_result"`
-	SettlementTx SettlementTransaction  `json:"settlement_tx"`
+// ApiExternalMatchBundle contains a match and a transaction that the client can submit on-chain
+type ApiExternalMatchBundle struct {
+	MatchResult  ApiExternalMatchResult   `json:"match_result"`
+	SettlementTx ApiSettlementTransaction `json:"settlement_tx"`
 }
 
 // ApiExternalMatchResult is the result of a request to generate an external match
@@ -33,8 +33,8 @@ type ApiExternalMatchResult struct {
 	Direction   string `json:"direction"`
 }
 
-// SettlementTransaction is an EVM transaction parameterization for settling an external match
-type SettlementTransaction struct {
+// ApiSettlementTransaction is an EVM transaction parameterization for settling an external match
+type ApiSettlementTransaction struct {
 	Type string `json:"type"`
 	To   string `json:"to"`
 	Data string `json:"data"`

--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -250,5 +250,5 @@ type ExternalMatchRequest struct {
 
 // ExternalMatchResponse is the response body for the ExternalMatch action
 type ExternalMatchResponse struct {
-	Bundle ExternalMatchBundle `json:"match_bundle"`
+	Bundle ApiExternalMatchBundle `json:"match_bundle"`
 }

--- a/client/external_match_client/client.go
+++ b/client/external_match_client/client.go
@@ -86,9 +86,8 @@ func (c *ExternalMatchClient) GetExternalMatchBundle(request *api_types.ApiExter
 	}
 
 	// Convert into the application level type
-	res := &ExternalMatchBundle{
+	return &ExternalMatchBundle{
 		MatchResult:  &response.Bundle.MatchResult,
 		SettlementTx: toSettlementTransaction(&response.Bundle.SettlementTx),
-	}
-	return res, nil
+	}, nil
 }


### PR DESCRIPTION
### Purpose
This PR makes two changes:
- Changes the return type supplied by the external match client to use geth-native types for transaction parameters
- Adds an example to the README for generating atomic matches

### Testing
- Tested this example against testnet