### PR TITLE
client: external-match-client: Unmarshal `value` from returned tx

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ func submitBundle(bundle external_match_client.ExternalMatchBundle) error {
 		GasFeeCap: new(big.Int).Mul(gasPrice, big.NewInt(2)),
 		Gas:       uint64(10000000),
 		To:        &bundle.SettlementTx.To,
-		Value:     big.NewInt(0),
+		Value:     bundle.SettlementTx.Value,
 		Data:      []byte(bundle.SettlementTx.Data),
 	})
 
@@ -343,6 +343,8 @@ func submitBundle(bundle external_match_client.ExternalMatchBundle) error {
 Renegade supports a specific set of tokens for external matches. These can be found at:
 - [Testnet (Arbitrum Sepolia)](https://github.com/renegade-fi/token-mappings/blob/main/testnet.json)
 - [Mainnet (Arbitrum One)](https://github.com/renegade-fi/token-mappings/blob/main/mainnet.json)
+
+*Note:* For external matches, Renegade supports swapping native ETH directly. To do so, specify the `baseMint` as `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`.
 
 In testnet, we use a set of mock ERC20s that match the mainnet tokens. For convenience while testing, you can use the Renegade faucet to fund your wallet with testnet tokens.
 This is most easily accessed through the API using the curl request below

--- a/client/api_types/api_external_match.go
+++ b/client/api_types/api_external_match.go
@@ -114,7 +114,8 @@ type ApiExternalMatchResult struct {
 
 // ApiSettlementTransaction is an EVM transaction parameterization for settling an external match
 type ApiSettlementTransaction struct {
-	Type string `json:"type"`
-	To   string `json:"to"`
-	Data string `json:"data"`
+	Type  string `json:"type"`
+	To    string `json:"to"`
+	Data  string `json:"data"`
+	Value string `json:"value"`
 }

--- a/client/external_match_client/client.go
+++ b/client/external_match_client/client.go
@@ -3,6 +3,7 @@ package external_match_client
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 
 	geth_common "github.com/ethereum/go-ethereum/common"
@@ -25,9 +26,10 @@ type ExternalMatchBundle struct {
 
 // SettlementTransaction is the application level analog to the ApiSettlementTransaction
 type SettlementTransaction struct {
-	Type string
-	To   geth_common.Address
-	Data []byte
+	Type  string
+	To    geth_common.Address
+	Data  []byte
+	Value *big.Int
 }
 
 // toSettlementTransaction converts an ApiSettlementTransaction to a SettlementTransaction
@@ -35,11 +37,14 @@ func toSettlementTransaction(tx *api_types.ApiSettlementTransaction) *Settlement
 	// Parse a geth address and bytes data from hex strings
 	to := geth_common.HexToAddress(tx.To)
 	data := geth_common.FromHex(tx.Data)
+	valueBytes := geth_common.FromHex(tx.Value)
+	value := big.NewInt(0).SetBytes(valueBytes)
 
 	return &SettlementTransaction{
-		Type: tx.Type,
-		To:   to,
-		Data: data,
+		Type:  tx.Type,
+		To:    to,
+		Data:  data,
+		Value: value,
 	}
 }
 


### PR DESCRIPTION
### Purpose
This PR adds a `value` field to the settlement transaction and unmarshals it from the relayer response. This is particularly relevant for external matches on native ETH, which must set `value = baseAmount`. 

### Testing
- Ran external matches on the native asset in mainnet