### PR TITLE
external-match-client: Support `receiverAddress` argument for match

### DIFF
--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -275,7 +275,11 @@ type TaskHistoryResponse struct {
 
 // ExternalMatchRequest is a request to generate an external match
 type ExternalMatchRequest struct {
-	ExternalOrder ApiExternalOrder `json:"external_order"`
+	ExternalOrder   ApiExternalOrder `json:"external_order"`
+	DoGasEstimation bool             `json:"do_gas_estimation"`
+	// ReceiverAddress is the address to receive the settlement,
+	// i.e. the address to which the darkpool will send tokens
+	ReceiverAddress *string `json:"receiver_address,omitempty"`
 }
 
 // ExternalMatchResponse is the response body for the ExternalMatch action
@@ -298,4 +302,7 @@ type ExternalQuoteResponse struct {
 type AssembleExternalQuoteRequest struct {
 	Quote           ApiSignedQuote `json:"signed_quote"`
 	DoGasEstimation bool           `json:"do_gas_estimation"`
+	// ReceiverAddress is the address to receive the settlement,
+	// i.e. the address to which the darkpool will send tokens
+	ReceiverAddress *string `json:"receiver_address,omitempty"`
 }

--- a/client/external_match_client/client.go
+++ b/client/external_match_client/client.go
@@ -132,9 +132,16 @@ func (c *ExternalMatchClient) GetExternalMatchQuote(
 func (c *ExternalMatchClient) AssembleExternalQuote(
 	quote *api_types.ApiSignedQuote,
 ) (*ExternalMatchBundle, error) {
+	return c.AssembleExternalQuoteWithReceiver(quote, nil /* receiverAddress */)
+}
+
+func (c *ExternalMatchClient) AssembleExternalQuoteWithReceiver(
+	quote *api_types.ApiSignedQuote,
+	receiverAddress *string,
+) (*ExternalMatchBundle, error) {
 	requestBody := api_types.AssembleExternalQuoteRequest{
 		Quote:           *quote,
-		DoGasEstimation: false,
+		ReceiverAddress: receiverAddress,
 	}
 
 	var response api_types.ExternalMatchResponse
@@ -164,8 +171,18 @@ func (c *ExternalMatchClient) AssembleExternalQuote(
 func (c *ExternalMatchClient) GetExternalMatchBundle(
 	request *api_types.ApiExternalOrder,
 ) (*ExternalMatchBundle, error) {
+	return c.GetExternalMatchBundleWithReceiver(request, nil /* receiverAddress */)
+}
+
+// GetExternalMatchBundleWithReceiver requests an external match bundle from the relayer
+// returns nil if no match is found
+func (c *ExternalMatchClient) GetExternalMatchBundleWithReceiver(
+	request *api_types.ApiExternalOrder,
+	receiverAddress *string,
+) (*ExternalMatchBundle, error) {
 	requestBody := api_types.ExternalMatchRequest{
-		ExternalOrder: *request,
+		ExternalOrder:   *request,
+		ReceiverAddress: receiverAddress,
 	}
 
 	var response api_types.ExternalMatchResponse


### PR DESCRIPTION
### Purpose
This PR adds support for specifying a `receiverAddress` for an external match, and adds an example for doing so.

### Testing
- [x] Tested the example in testnet