### PR TITLE
client: external-match-client: Add `GasSponsored` flag to bundle

### DIFF
--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -293,7 +293,8 @@ type ExternalMatchRequest struct {
 
 // ExternalMatchResponse is the response body for the ExternalMatch action
 type ExternalMatchResponse struct {
-	Bundle ApiExternalMatchBundle `json:"match_bundle"`
+	Bundle       ApiExternalMatchBundle `json:"match_bundle"`
+	GasSponsored bool                   `json:"is_sponsored"`
 }
 
 // ExternalQuoteRequest is a request to fetch an external match quote

--- a/client/external_match_client/client.go
+++ b/client/external_match_client/client.go
@@ -33,6 +33,11 @@ type ExternalMatchBundle struct {
 	Receive      *api_types.ApiExternalAssetTransfer
 	Send         *api_types.ApiExternalAssetTransfer
 	SettlementTx *SettlementTransaction
+	// Whether the match has received gas sponsorship
+	//
+	// If `true`, the bundle is routed through a gas rebate contract that
+	// refunds the gas used by the match to the configured address
+	GasSponsored bool
 }
 
 // SettlementTransaction is the application level analog to the ApiSettlementTransaction
@@ -278,6 +283,7 @@ func (c *ExternalMatchClient) AssembleExternalMatchWithOptions(
 		Receive:      &response.Bundle.Receive,
 		Send:         &response.Bundle.Send,
 		SettlementTx: toSettlementTransaction(&response.Bundle.SettlementTx),
+		GasSponsored: response.GasSponsored,
 	}, nil
 }
 
@@ -337,6 +343,7 @@ func (c *ExternalMatchClient) GetExternalMatchBundleWithOptions(
 	return &ExternalMatchBundle{
 		MatchResult:  &response.Bundle.MatchResult,
 		SettlementTx: toSettlementTransaction(&response.Bundle.SettlementTx),
+		GasSponsored: response.GasSponsored,
 	}, nil
 }
 

--- a/examples/05_gas_sponsored_match/main.go
+++ b/examples/05_gas_sponsored_match/main.go
@@ -101,6 +101,11 @@ func getQuoteAndSubmitWithGasSponsorship(
 		return nil
 	}
 
+	if !bundle.GasSponsored {
+		fmt.Println("Bundle was not sponsored, abandoning...")
+		return nil
+	}
+
 	// 3. Submit the bundle
 	fmt.Println("Submitting bundle...")
 	if err := submitBundle(*bundle); err != nil {


### PR DESCRIPTION
### Purpose
This PR adds a `GasSponsorship` flag to the bundle returned by the quote assembly method.

### Testing
- [x] Tested the gas sponsorship example