### PR TITLE
client: external-match-client: Add `GetFees` method to fetch match fee

### DIFF
--- a/client/api_types/api_external_match.go
+++ b/client/api_types/api_external_match.go
@@ -175,3 +175,9 @@ type ApiSettlementTransaction struct { //nolint:revive
 	Data  string `json:"data"`
 	Value string `json:"value"`
 }
+
+// ApiExternalMatchFee represents the fees for a given asset in external matches
+type ApiExternalMatchFee struct { //nolint:revive
+	RelayerFee  string `json:"relayer_fee"`
+	ProtocolFee string `json:"protocol_fee"`
+}

--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -11,6 +11,8 @@ const (
 	// --- Orderbook Endpoints --- //
 	// GetSupportedTokensPath is the path for the GetSupportedTokens action
 	GetSupportedTokensPath = "/v0/supported-tokens"
+	// GetFeeForAssetPath is the path for the GetFeeForAsset action
+	GetFeeForAssetPath = "/v0/order_book/external-match-fee"
 
 	// --- Wallet Endpoints --- //
 	// GetWalletPath is the path for the GetWallet action
@@ -64,6 +66,11 @@ type WalletUpdateAuthorization struct {
 	StatementSig *string `json:"statement_sig"`
 	// NewRootKey is the root key for the new wallet, if the client prefers to rotate the root key
 	NewRootKey *string `json:"new_root_key"`
+}
+
+// BuildGetFeeForAssetPath builds the path for the GetFeeForAsset action
+func BuildGetFeeForAssetPath(mint string) string {
+	return fmt.Sprintf("%s?mint=%s", GetFeeForAssetPath, mint)
 }
 
 // BuildGetWalletPath builds the path for the GetWallet action

--- a/client/external_match_client/client.go
+++ b/client/external_match_client/client.go
@@ -3,10 +3,7 @@ package external_match_client //nolint:revive
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"net/http"
-
-	geth_common "github.com/ethereum/go-ethereum/common"
 
 	"github.com/renegade-fi/golang-sdk/client"
 	"github.com/renegade-fi/golang-sdk/client/api_types"
@@ -21,139 +18,6 @@ const (
 	mainnetRelayerBaseUrl = "https://mainnet.cluster0.renegade.fi:3000"
 	apiKeyHeader          = "X-Renegade-Api-Key" //nolint:gosec
 )
-
-// -----------------
-// | Request Types |
-// -----------------
-
-// ExternalMatchBundle is the application level analog to the ApiExternalMatchBundle
-type ExternalMatchBundle struct {
-	MatchResult  *api_types.ApiExternalMatchResult
-	Fees         *api_types.ApiFee
-	Receive      *api_types.ApiExternalAssetTransfer
-	Send         *api_types.ApiExternalAssetTransfer
-	SettlementTx *SettlementTransaction
-	// Whether the match has received gas sponsorship
-	//
-	// If `true`, the bundle is routed through a gas rebate contract that
-	// refunds the gas used by the match to the configured address
-	GasSponsored bool
-}
-
-// SettlementTransaction is the application level analog to the ApiSettlementTransaction
-type SettlementTransaction struct {
-	Type  string
-	To    geth_common.Address
-	Data  []byte
-	Value *big.Int
-}
-
-// toSettlementTransaction converts an ApiSettlementTransaction to a SettlementTransaction
-func toSettlementTransaction(tx *api_types.ApiSettlementTransaction) *SettlementTransaction {
-	// Parse a geth address and bytes data from hex strings
-	to := geth_common.HexToAddress(tx.To)
-	data := geth_common.FromHex(tx.Data)
-	valueBytes := geth_common.FromHex(tx.Value)
-	value := big.NewInt(0).SetBytes(valueBytes)
-
-	return &SettlementTransaction{
-		Type:  tx.Type,
-		To:    to,
-		Data:  data,
-		Value: value,
-	}
-}
-
-// AssembleExternalMatchOptions represents the options for an assembly request
-type AssembleExternalMatchOptions struct {
-	ReceiverAddress *string
-	DoGasEstimation bool
-	UpdatedOrder    *api_types.ApiExternalOrder
-	// RequestGasSponsorship is a flag to request gas sponsorship for the settlement tx
-	//
-	// This is subject to rate limit by the auth server, but if approved will refund the gas spent
-	// on the settlement tx to the address specified in `GasRefundAddress`. If no refund address is
-	// specified, the refund is directed to `tx.origin`
-	RequestGasSponsorship bool
-	// GasRefundAddress is the address to refund the gas to
-	//
-	// This is ignored if `RequestGasSponsorship` is false
-	GasRefundAddress *string
-}
-
-// WithReceiverAddress sets the receiver address for the assembly options
-func (o *AssembleExternalMatchOptions) WithReceiverAddress(address *string) *AssembleExternalMatchOptions {
-	o.ReceiverAddress = address
-	return o
-}
-
-// WithGasEstimation sets whether to perform gas estimation
-func (o *AssembleExternalMatchOptions) WithGasEstimation(estimate bool) *AssembleExternalMatchOptions {
-	o.DoGasEstimation = estimate
-	return o
-}
-
-// WithUpdatedOrder sets the updated order for the assembly options
-func (o *AssembleExternalMatchOptions) WithUpdatedOrder(order *api_types.ApiExternalOrder) *AssembleExternalMatchOptions {
-	o.UpdatedOrder = order
-	return o
-}
-
-// WithRequestGasSponsorship sets whether to request gas sponsorship
-func (o *AssembleExternalMatchOptions) WithRequestGasSponsorship(request bool) *AssembleExternalMatchOptions {
-	o.RequestGasSponsorship = request
-	return o
-}
-
-// WithGasRefundAddress sets the gas refund address for the assembly options
-func (o *AssembleExternalMatchOptions) WithGasRefundAddress(address *string) *AssembleExternalMatchOptions {
-	o.GasRefundAddress = address
-	return o
-}
-
-// BuildRequestPath builds the request path for the assembly options
-func (o *AssembleExternalMatchOptions) BuildRequestPath() string {
-	path := api_types.AssembleExternalQuotePath
-	path += fmt.Sprintf("?%s=%t", api_types.RequestGasSponsorshipParam, o.RequestGasSponsorship)
-	if o.GasRefundAddress != nil {
-		path += fmt.Sprintf("&%s=%s", api_types.GasRefundAddressParam, *o.GasRefundAddress)
-	}
-
-	return path
-}
-
-// NewAssembleExternalMatchOptions creates a new AssembleExternalMatchOptions with default values
-func NewAssembleExternalMatchOptions() *AssembleExternalMatchOptions {
-	return &AssembleExternalMatchOptions{
-		ReceiverAddress: nil,
-		DoGasEstimation: false,
-		UpdatedOrder:    nil,
-	}
-}
-
-// ExternalMatchOptions represents the options for an external match request
-//
-// Deprecated: Use AssembleExternalMatchOptions instead
-type ExternalMatchOptions struct {
-	AssembleExternalMatchOptions
-}
-
-// BuildRequestPath builds the request path for the external match options
-func (o *ExternalMatchOptions) BuildRequestPath() string {
-	path := api_types.GetExternalMatchBundlePath
-	path += fmt.Sprintf("?%s=%t", api_types.RequestGasSponsorshipParam, o.RequestGasSponsorship)
-	if o.GasRefundAddress != nil {
-		path += fmt.Sprintf("&%s=%s", api_types.GasRefundAddressParam, *o.GasRefundAddress)
-	}
-	return path
-}
-
-// NewExternalMatchOptions creates a new ExternalMatchOptions with default values
-func NewExternalMatchOptions() *ExternalMatchOptions {
-	return &ExternalMatchOptions{
-		AssembleExternalMatchOptions: *NewAssembleExternalMatchOptions(),
-	}
-}
 
 // -------------------------
 // | Client Implementation |
@@ -194,6 +58,10 @@ func NewExternalMatchClient(
 	}
 }
 
+// ----------------
+// | Metadata API |
+// ----------------
+
 // GetSupportedTokens requests the list of supported tokens from the relayer
 func (c *ExternalMatchClient) GetSupportedTokens() ([]api_types.ApiToken, error) {
 	var response api_types.GetSupportedTokensResponse
@@ -208,6 +76,30 @@ func (c *ExternalMatchClient) GetSupportedTokens() ([]api_types.ApiToken, error)
 
 	return response.Tokens, nil
 }
+
+// GetFeeForAsset requests the fees for a given base token
+func (c *ExternalMatchClient) GetFeeForAsset(addr *string) (*ExternalMatchFee, error) {
+	var response api_types.ApiExternalMatchFee
+	err := c.relayerHttpClient.GetJSON(
+		api_types.BuildGetFeeForAssetPath(*addr),
+		nil, // body
+		&response,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedFee, err := toExternalMatchFee(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsedFee, nil
+}
+
+// ------------------------
+// | Quote + Assembly API |
+// ------------------------
 
 // GetExternalMatchQuote requests a quote from the relayer
 // returns nil if no match is found

--- a/client/external_match_client/types.go
+++ b/client/external_match_client/types.go
@@ -1,0 +1,177 @@
+package external_match_client //nolint:revive
+
+import (
+	"fmt"
+	"math/big"
+	"strconv"
+
+	geth_common "github.com/ethereum/go-ethereum/common"
+
+	"github.com/renegade-fi/golang-sdk/client/api_types"
+)
+
+// --------------------------
+// | Request/Response Types |
+// --------------------------
+
+// ExternalMatchBundle is the application level analog to the ApiExternalMatchBundle
+type ExternalMatchBundle struct {
+	MatchResult  *api_types.ApiExternalMatchResult
+	Fees         *api_types.ApiFee
+	Receive      *api_types.ApiExternalAssetTransfer
+	Send         *api_types.ApiExternalAssetTransfer
+	SettlementTx *SettlementTransaction
+	// Whether the match has received gas sponsorship
+	//
+	// If `true`, the bundle is routed through a gas rebate contract that
+	// refunds the gas used by the match to the configured address
+	GasSponsored bool
+}
+
+// SettlementTransaction is the application level analog to the ApiSettlementTransaction
+type SettlementTransaction struct {
+	Type  string
+	To    geth_common.Address
+	Data  []byte
+	Value *big.Int
+}
+
+// toSettlementTransaction converts an ApiSettlementTransaction to a SettlementTransaction
+func toSettlementTransaction(tx *api_types.ApiSettlementTransaction) *SettlementTransaction {
+	// Parse a geth address and bytes data from hex strings
+	to := geth_common.HexToAddress(tx.To)
+	data := geth_common.FromHex(tx.Data)
+	valueBytes := geth_common.FromHex(tx.Value)
+	value := big.NewInt(0).SetBytes(valueBytes)
+
+	return &SettlementTransaction{
+		Type:  tx.Type,
+		To:    to,
+		Data:  data,
+		Value: value,
+	}
+}
+
+// ExternalMatchFee represents the fees for a given asset in external matches
+type ExternalMatchFee struct {
+	RelayerFee  float64
+	ProtocolFee float64
+}
+
+// Total returns the total fee for the asset
+func (f *ExternalMatchFee) Total() float64 {
+	return f.RelayerFee + f.ProtocolFee
+}
+
+// toExternalMatchFee converts an ApiExternalMatchFee to an ExternalMatchFee
+func toExternalMatchFee(fee *api_types.ApiExternalMatchFee) (*ExternalMatchFee, error) {
+	relayerFee, err := strconv.ParseFloat(fee.RelayerFee, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse relayer fee: %w", err)
+	}
+
+	protocolFee, err := strconv.ParseFloat(fee.ProtocolFee, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse protocol fee: %w", err)
+	}
+
+	return &ExternalMatchFee{
+		RelayerFee:  relayerFee,
+		ProtocolFee: protocolFee,
+	}, nil
+}
+
+// -----------------
+// | Options Types |
+// -----------------
+
+// AssembleExternalMatchOptions represents the options for an assembly request
+type AssembleExternalMatchOptions struct {
+	ReceiverAddress *string
+	DoGasEstimation bool
+	UpdatedOrder    *api_types.ApiExternalOrder
+	// RequestGasSponsorship is a flag to request gas sponsorship for the settlement tx
+	//
+	// This is subject to rate limit by the auth server, but if approved will refund the gas spent
+	// on the settlement tx to the address specified in `GasRefundAddress`. If no refund address is
+	// specified, the refund is directed to `tx.origin`
+	RequestGasSponsorship bool
+	// GasRefundAddress is the address to refund the gas to
+	//
+	// This is ignored if `RequestGasSponsorship` is false
+	GasRefundAddress *string
+}
+
+// WithReceiverAddress sets the receiver address for the assembly options
+func (o *AssembleExternalMatchOptions) WithReceiverAddress(address *string) *AssembleExternalMatchOptions {
+	o.ReceiverAddress = address
+	return o
+}
+
+// WithGasEstimation sets whether to perform gas estimation
+func (o *AssembleExternalMatchOptions) WithGasEstimation(estimate bool) *AssembleExternalMatchOptions {
+	o.DoGasEstimation = estimate
+	return o
+}
+
+// WithUpdatedOrder sets the updated order for the assembly options
+func (o *AssembleExternalMatchOptions) WithUpdatedOrder(order *api_types.ApiExternalOrder) *AssembleExternalMatchOptions {
+	o.UpdatedOrder = order
+	return o
+}
+
+// WithRequestGasSponsorship sets whether to request gas sponsorship
+func (o *AssembleExternalMatchOptions) WithRequestGasSponsorship(request bool) *AssembleExternalMatchOptions {
+	o.RequestGasSponsorship = request
+	return o
+}
+
+// WithGasRefundAddress sets the gas refund address for the assembly options
+func (o *AssembleExternalMatchOptions) WithGasRefundAddress(address *string) *AssembleExternalMatchOptions {
+	o.GasRefundAddress = address
+	return o
+}
+
+// BuildRequestPath builds the request path for the assembly options
+func (o *AssembleExternalMatchOptions) BuildRequestPath() string {
+	path := api_types.AssembleExternalQuotePath
+	path += fmt.Sprintf("?%s=%t", api_types.RequestGasSponsorshipParam, o.RequestGasSponsorship)
+	if o.GasRefundAddress != nil {
+		path += fmt.Sprintf("&%s=%s", api_types.GasRefundAddressParam, *o.GasRefundAddress)
+	}
+
+	return path
+}
+
+// NewAssembleExternalMatchOptions creates a new AssembleExternalMatchOptions with default values
+func NewAssembleExternalMatchOptions() *AssembleExternalMatchOptions {
+	return &AssembleExternalMatchOptions{
+		ReceiverAddress: nil,
+		DoGasEstimation: false,
+		UpdatedOrder:    nil,
+	}
+}
+
+// ExternalMatchOptions represents the options for an external match request
+//
+// Deprecated: Use AssembleExternalMatchOptions instead
+type ExternalMatchOptions struct {
+	AssembleExternalMatchOptions
+}
+
+// BuildRequestPath builds the request path for the external match options
+func (o *ExternalMatchOptions) BuildRequestPath() string {
+	path := api_types.GetExternalMatchBundlePath
+	path += fmt.Sprintf("?%s=%t", api_types.RequestGasSponsorshipParam, o.RequestGasSponsorship)
+	if o.GasRefundAddress != nil {
+		path += fmt.Sprintf("&%s=%s", api_types.GasRefundAddressParam, *o.GasRefundAddress)
+	}
+	return path
+}
+
+// NewExternalMatchOptions creates a new ExternalMatchOptions with default values
+func NewExternalMatchOptions() *ExternalMatchOptions {
+	return &ExternalMatchOptions{
+		AssembleExternalMatchOptions: *NewAssembleExternalMatchOptions(),
+	}
+}

--- a/examples/07_get_fees/main.go
+++ b/examples/07_get_fees/main.go
@@ -1,0 +1,38 @@
+// This example demonstrates how to get fees for a given asset
+package main
+
+import (
+	"fmt"
+	"os"
+
+	external_match_client "github.com/renegade-fi/golang-sdk/client/external_match_client"
+	"github.com/renegade-fi/golang-sdk/wallet"
+)
+
+func main() {
+	// Get API credentials from environment
+	apiKey := os.Getenv("EXTERNAL_MATCH_KEY")
+	apiSecret := os.Getenv("EXTERNAL_MATCH_SECRET")
+	if apiKey == "" || apiSecret == "" {
+		panic("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
+	}
+
+	apiSecretKey, err := new(wallet.HmacKey).FromBase64String(apiSecret)
+	if err != nil {
+		panic(err)
+	}
+
+	// Get fees for WETH
+	externalMatchClient := external_match_client.NewTestnetExternalMatchClient(apiKey, &apiSecretKey)
+
+	mint := "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a" // Testnet WETH
+	fees, err := externalMatchClient.GetFeeForAsset(&mint)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Fees for WETH:\n")
+	fmt.Printf("Relayer Fee: %v\n", fees.RelayerFee)
+	fmt.Printf("Protocol Fee: %v\n", fees.ProtocolFee)
+	fmt.Printf("Total Fee: %v\n", fees.Total())
+}


### PR DESCRIPTION
### Purpose
This PR adds a `GetFees` method to the golang SDK which fetches the fees for a given asset.

### Testing
- [x] Example runs correctly