### PR TITLE
client: external_match_client: in-kind gas sponsorship support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode/**
 **/.env
 **/.DS_Store
+
+**/.env*

--- a/client/api_types/api_external_match.go
+++ b/client/api_types/api_external_match.go
@@ -148,6 +148,8 @@ type ApiExternalQuote struct { //nolint:revive
 type ApiSignedQuote struct { //nolint:revive
 	Quote     ApiExternalQuote `json:"quote"`
 	Signature string           `json:"signature"`
+	// The signed gas sponsorship info, if sponsorship was requested
+	GasSponsorshipInfo *ApiSignedGasSponsorshipInfo
 }
 
 // ApiExternalMatchBundle contains a match and a transaction that the client can submit on-chain
@@ -180,4 +182,23 @@ type ApiSettlementTransaction struct { //nolint:revive
 type ApiExternalMatchFee struct { //nolint:revive
 	RelayerFee  string `json:"relayer_fee"`
 	ProtocolFee string `json:"protocol_fee"`
+}
+
+// ApiSignedGasSponsorshipInfo contains signed metadata regarding gas sponsorship for a quote
+type ApiSignedGasSponsorshipInfo struct { //nolint:revive
+	// The gas sponsorship info
+	GasSponsorshipInfo ApiGasSponsorshipInfo `json:"gas_sponsorship_info"`
+	// The auth server's signature over the gas sponsorship info
+	Signature string `json:"signature"`
+}
+
+// ApiGasSponsorshipInfo contains metadata regarding gas sponsorship for a quote
+type ApiGasSponsorshipInfo struct { //nolint:revive
+	// The amount to be refunded as a result of gas sponsorship.
+	// This amount is firm, it will not change when the quote is assembled.
+	RefundAmount Amount `json:"refund_amount"`
+	// Whether the refund is in terms of native ETH.
+	RefundNativeETH bool `json:"refund_native_eth"`
+	// The address to which the refund will be sent, if set explicitly.
+	RefundAddress *string `json:"refund_address,omitempty"`
 }

--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -50,10 +50,12 @@ const (
 	AssembleExternalQuotePath = "/v0/matching-engine/assemble-external-match"
 
 	// --- External Match Query Params --- //
-	// RequestGasSponsorshipParam is the query param used to request gas sponsorship
-	RequestGasSponsorshipParam = "use_gas_sponsorship"
+	// DisableGasSponsorshipParam is the query param used to disable gas sponsorship
+	DisableGasSponsorshipParam = "disable_gas_sponsorship"
 	// GasRefundAddressParam is the query param used to specify the gas refund address
 	GasRefundAddressParam = "refund_address"
+	// RefundNativeEthParam is the query param used to specify whether to refund the gas in native ETH
+	RefundNativeEthParam = "refund_native_eth"
 )
 
 // ScalarLimbs is an array of uint32 limbs
@@ -302,6 +304,8 @@ type ExternalMatchRequest struct {
 type ExternalMatchResponse struct {
 	Bundle       ApiExternalMatchBundle `json:"match_bundle"`
 	GasSponsored bool                   `json:"is_sponsored"`
+	// The gas sponsorship info, if the match was sponsored
+	GasSponsorshipInfo *ApiGasSponsorshipInfo `json:"gas_sponsorship_info,omitempty"`
 }
 
 // ExternalQuoteRequest is a request to fetch an external match quote
@@ -311,17 +315,28 @@ type ExternalQuoteRequest struct {
 
 // ExternalQuoteResponse is the response body for the ExternalQuote action
 type ExternalQuoteResponse struct {
-	Quote ApiSignedQuote `json:"signed_quote"`
+	Quote SignedQuoteResponse `json:"signed_quote"`
+	// The signed gas sponsorship info, if sponsorship was requested
+	GasSponsorshipInfo *ApiSignedGasSponsorshipInfo `json:"gas_sponsorship_info,omitempty"`
 }
 
 // AssembleExternalQuoteRequest is a request to assemble an external match quote
 // into a settlement transaction
 type AssembleExternalQuoteRequest struct {
-	Quote           ApiSignedQuote `json:"signed_quote"`
-	DoGasEstimation bool           `json:"do_gas_estimation"`
+	Quote           SignedQuoteResponse `json:"signed_quote"`
+	DoGasEstimation bool                `json:"do_gas_estimation"`
 	// ReceiverAddress is the address to receive the settlement,
 	// i.e. the address to which the darkpool will send tokens
 	ReceiverAddress *string `json:"receiver_address,omitempty"`
 	// UpdatedOrder is the order to use for the assembly, if different from the quote
 	UpdatedOrder *ApiExternalOrder `json:"updated_order,omitempty"`
+	// GasSponsorshipInfo is the gas sponsorship info applied to the quote, if any
+	GasSponsorshipInfo *ApiSignedGasSponsorshipInfo `json:"gas_sponsorship_info,omitempty"`
+}
+
+// SignedQuoteResponse represents the shape of a signed quote payload directly returned by
+// the auth server's API
+type SignedQuoteResponse struct {
+	Quote     ApiExternalQuote `json:"quote"`
+	Signature string           `json:"signature"`
 }


### PR DESCRIPTION
This PR adds support for in-kind gas sponsorship to the external match client

### Testing
- [x] Ran all existing examples, asserted that each worked as expect wrt new gas sponsorship defaults

### TODO
- Update gas sponsorship example & add new one