### PR TITLE
docs, examples: update README & gas sponsorship ex, add in-kind ex

### DIFF
--- a/examples/05_native_eth_gas_sponsorship/main.go
+++ b/examples/05_native_eth_gas_sponsorship/main.go
@@ -48,14 +48,19 @@ func main() {
 	}
 }
 
-// getQuoteAndSubmitWithGasSponsorship gets a quote, assembles it with gas sponsorship, then submits
+// getQuoteAndSubmitWithGasSponsorship gets a quote with gas sponsorship, assembles it, then submits
 func getQuoteAndSubmitWithGasSponsorship(
 	order *api_types.ApiExternalOrder,
 	client *external_match_client.ExternalMatchClient,
 ) error {
-	// 1. Get a quote from the relayer
-	fmt.Println("Getting quote...")
-	quote, err := client.GetExternalMatchQuote(order)
+	// 1. Get a quote from the relayer, explicitly requesting native ETH gas sponsorship
+	fmt.Println("Getting quote with gas sponsorship...")
+	refundAddr := gasRefundAddress
+	options := external_match_client.NewExternalQuoteOptions().
+		WithRefundNativeEth(true).
+		WithGasRefundAddress(&refundAddr)
+
+	quote, err := client.GetExternalMatchQuoteWithOptions(order, options)
 	if err != nil {
 		return err
 	}
@@ -65,14 +70,9 @@ func getQuoteAndSubmitWithGasSponsorship(
 		return nil
 	}
 
-	// 2. Assemble the bundle with gas sponsorship
-	fmt.Println("Assembling bundle with gas sponsorship...")
-	refundAddr := gasRefundAddress
-	options := external_match_client.NewAssembleExternalMatchOptions().
-		WithRequestGasSponsorship(true).
-		WithGasRefundAddress(&refundAddr)
-
-	bundle, err := client.AssembleExternalMatchWithOptions(quote, options)
+	// 2. Assemble the bundle
+	fmt.Println("Assembling bundle...")
+	bundle, err := client.AssembleExternalQuote(quote)
 	if err != nil {
 		return err
 	}

--- a/examples/06_exact_amount_out/main.go
+++ b/examples/06_exact_amount_out/main.go
@@ -66,22 +66,3 @@ func getQuoteWithExactAmount(order *api_types.ApiExternalOrder, client *external
 	// You can now assemble the quote and submit a bundle, see `01_external_match` for an example
 	return nil
 }
-
-// -----------
-// | Helpers |
-// -----------
-
-func findTokenAddr(symbol string, client *external_match_client.ExternalMatchClient) (string, error) {
-	tokens, err := client.GetSupportedTokens()
-	if err != nil {
-		return "", err
-	}
-
-	for _, token := range tokens {
-		if token.Symbol == symbol {
-			return token.Address, nil
-		}
-	}
-
-	return "", fmt.Errorf("token not found")
-}

--- a/examples/08_in_kind_gas_sponsorship/main.go
+++ b/examples/08_in_kind_gas_sponsorship/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/renegade-fi/golang-sdk/client/api_types"
+	external_match_client "github.com/renegade-fi/golang-sdk/client/external_match_client"
+	"github.com/renegade-fi/golang-sdk/examples/common"
+)
+
+func main() {
+	client, err := common.CreateExternalMatchClient()
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch token mappings from the relayer
+	quoteMint, err := common.FindTokenAddr("USDC", client)
+	if err != nil {
+		panic(err)
+	}
+	baseMint, err := common.FindTokenAddr("WETH", client)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create order for 20 USDC worth of WETH
+	quoteAmount := new(big.Int).SetUint64(20_000_000) // $20 USDC
+	minFillSize := big.NewInt(0)
+	order, err := api_types.NewExternalOrderBuilder().
+		WithQuoteMint(quoteMint).
+		WithBaseMint(baseMint).
+		WithQuoteAmount(api_types.Amount(*quoteAmount)).
+		WithSide("Sell").
+		WithMinFillSize(api_types.Amount(*minFillSize)).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	if err := getQuoteAndSubmitWithGasSponsorship(order, client); err != nil {
+		panic(err)
+	}
+}
+
+// getQuoteAndSubmitWithGasSponsorship gets a quote with gas sponsorship, assembles it, then submits
+func getQuoteAndSubmitWithGasSponsorship(
+	order *api_types.ApiExternalOrder,
+	client *external_match_client.ExternalMatchClient,
+) error {
+	// 1. Get a quote from the relayer, explicitly requesting in-kind gas sponsorship.
+	fmt.Println("Getting quote with gas sponsorship...")
+	// When you leave the `refundAddress` unset, the in-kind refund is directed to the receiver address.
+	// This is equivalent to the trade itself having a better price, so the price in the quote will be
+	// updated to reflect this
+	quoteOptions := external_match_client.NewExternalQuoteOptions().
+		WithDisableGasSponsorship(false). // Note that this is false by default
+		WithRefundNativeEth(false)        // Note that this is false by default
+
+	quote, err := client.GetExternalMatchQuoteWithOptions(order, quoteOptions)
+	if err != nil {
+		return err
+	}
+
+	if quote == nil {
+		fmt.Println("No quote found")
+		return nil
+	}
+
+	// 2. Assemble the bundle
+	fmt.Println("Assembling bundle...")
+	receiverAddress := "0xC5fE800A3D92112473e4E811296F194DA7b26BA7"
+	assemblyOptions := external_match_client.NewAssembleExternalMatchOptions().
+		WithReceiverAddress(&receiverAddress)
+
+	bundle, err := client.AssembleExternalMatchWithOptions(quote, assemblyOptions)
+	if err != nil {
+		return err
+	}
+
+	if bundle == nil {
+		fmt.Println("No bundle found")
+		return nil
+	}
+
+	if !bundle.GasSponsored {
+		fmt.Println("Bundle was not sponsored, abandoning...")
+		return nil
+	}
+
+	// 3. Submit the bundle
+	fmt.Println("Submitting bundle...")
+	if err := common.SubmitBundle(*bundle); err != nil {
+		return fmt.Errorf("failed to submit bundle: %w", err)
+	}
+
+	fmt.Print("Bundle submitted successfully!\n\n")
+	return nil
+}


### PR DESCRIPTION
This PR updates the existing gas sponsorship example, and adds a new in-kind gas sponsorship example. Both of these examples run as expected. Additionally, we update the README to mention in-kind gas sponsorship.