### PR TITLE
client: api_types: remove sponsorship info from assembly req

### DIFF
--- a/client/api_types/api_external_match.go
+++ b/client/api_types/api_external_match.go
@@ -189,6 +189,8 @@ type ApiSignedGasSponsorshipInfo struct { //nolint:revive
 	// The gas sponsorship info
 	GasSponsorshipInfo ApiGasSponsorshipInfo `json:"gas_sponsorship_info"`
 	// The auth server's signature over the gas sponsorship info
+	//
+	// Deprecated: Gas sponsorship info is no longer signed
 	Signature string `json:"signature"`
 }
 

--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -330,8 +330,6 @@ type AssembleExternalQuoteRequest struct {
 	ReceiverAddress *string `json:"receiver_address,omitempty"`
 	// UpdatedOrder is the order to use for the assembly, if different from the quote
 	UpdatedOrder *ApiExternalOrder `json:"updated_order,omitempty"`
-	// GasSponsorshipInfo is the gas sponsorship info applied to the quote, if any
-	GasSponsorshipInfo *ApiSignedGasSponsorshipInfo `json:"gas_sponsorship_info,omitempty"`
 }
 
 // SignedQuoteResponse represents the shape of a signed quote payload directly returned by

--- a/client/external_match_client/client.go
+++ b/client/external_match_client/client.go
@@ -166,11 +166,10 @@ func (c *ExternalMatchClient) AssembleExternalMatchWithOptions(
 		Signature: quote.Signature,
 	}
 	requestBody := api_types.AssembleExternalQuoteRequest{
-		Quote:              signedQuote,
-		GasSponsorshipInfo: quote.GasSponsorshipInfo,
-		ReceiverAddress:    options.ReceiverAddress,
-		DoGasEstimation:    options.DoGasEstimation,
-		UpdatedOrder:       options.UpdatedOrder,
+		Quote:           signedQuote,
+		ReceiverAddress: options.ReceiverAddress,
+		DoGasEstimation: options.DoGasEstimation,
+		UpdatedOrder:    options.UpdatedOrder,
 	}
 
 	var response api_types.ExternalMatchResponse


### PR DESCRIPTION
This PR removes the `gas_sponsorship_info` field from the `AssembleExternalQuoteRequest` struct, as it is no longer needed by the API.

### Testing
- [x] Ran all SDK examples, asserting they run as expected