### PR TITLE
external-match-client: client, types: Expose shared bundles and add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,8 +415,8 @@ See example [`02_external_quote_validation`](examples/02_external_quote_validati
 ## Rate Limits
 The rate limits for external match endpoints are as follows: 
 - **Quote**: 100 requests per minute
-- **Assemble**: 5 _unsettled_ bundles per minute. That is, if an assembled bundle is submitted on-chain, the rate limiter will reset. 
-If an assembled match is not settled on-chain, the rate limiter will remove one token from the per-minute allowance.
+- **Assemble (Exclusive Bundle)**: 5 _unsettled_ bundles per minute. That is, if an assembled bundle is submitted on-chain, the rate limiter will reset. 
+- **Assemble (Shared Bundle)**: 50 _unsettled_ shared bundles per minute. A shared bundle is an assembled bundle that the relayer may send to multiple external parties, rather than enforcing that only one external party can settle the bundle. See [`examples/09_shared_bundle/main.go`](examples/09_shared_bundle/main.go) for an example of how to assemble a shared bundle.
 
 ## Supported Tokens
 Renegade supports a specific set of tokens for external matches. These can be found at:

--- a/client/api_types/request_response_types.go
+++ b/client/api_types/request_response_types.go
@@ -325,6 +325,7 @@ type ExternalQuoteResponse struct {
 type AssembleExternalQuoteRequest struct {
 	Quote           SignedQuoteResponse `json:"signed_quote"`
 	DoGasEstimation bool                `json:"do_gas_estimation"`
+	AllowShared     bool                `json:"allow_shared"`
 	// ReceiverAddress is the address to receive the settlement,
 	// i.e. the address to which the darkpool will send tokens
 	ReceiverAddress *string `json:"receiver_address,omitempty"`

--- a/client/external_match_client/client.go
+++ b/client/external_match_client/client.go
@@ -170,6 +170,7 @@ func (c *ExternalMatchClient) AssembleExternalMatchWithOptions(
 		ReceiverAddress: options.ReceiverAddress,
 		DoGasEstimation: options.DoGasEstimation,
 		UpdatedOrder:    options.UpdatedOrder,
+		AllowShared:     options.AllowShared,
 	}
 
 	var response api_types.ExternalMatchResponse

--- a/client/external_match_client/types.go
+++ b/client/external_match_client/types.go
@@ -147,7 +147,14 @@ func NewExternalQuoteOptions() *ExternalQuoteOptions {
 type AssembleExternalMatchOptions struct {
 	ReceiverAddress *string
 	DoGasEstimation bool
-	UpdatedOrder    *api_types.ApiExternalOrder
+	// AllowShared is a flag to allow the assembly of a shared quote
+	//
+	// If true, the relayer will not enforce exclusive access to the bundle returned in the
+	// assemble step. I.e. the relayer may send the same bundle to another client.
+	//
+	// This affords the client a much higher rate limit
+	AllowShared  bool
+	UpdatedOrder *api_types.ApiExternalOrder
 	// RequestGasSponsorship is a flag to request gas sponsorship for the settlement tx
 	//
 	// This is subject to rate limit by the auth server, but if approved will refund the gas spent
@@ -173,6 +180,12 @@ func (o *AssembleExternalMatchOptions) WithReceiverAddress(address *string) *Ass
 // WithGasEstimation sets whether to perform gas estimation
 func (o *AssembleExternalMatchOptions) WithGasEstimation(estimate bool) *AssembleExternalMatchOptions {
 	o.DoGasEstimation = estimate
+	return o
+}
+
+// WithAllowShared sets whether to allow the assembly of a shared quote
+func (o *AssembleExternalMatchOptions) WithAllowShared(allowShared bool) *AssembleExternalMatchOptions {
+	o.AllowShared = allowShared
 	return o
 }
 

--- a/examples/09_shared_bundle/main.go
+++ b/examples/09_shared_bundle/main.go
@@ -1,0 +1,82 @@
+// Example of assembling a shared bundle
+package main
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/renegade-fi/golang-sdk/client/api_types"
+	"github.com/renegade-fi/golang-sdk/client/external_match_client"
+	"github.com/renegade-fi/golang-sdk/examples/common"
+)
+
+func main() {
+	client, err := common.CreateExternalMatchClient()
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch token mappings from the relayer
+	quoteMint, err := common.FindTokenAddr("USDC", client)
+	if err != nil {
+		panic(err)
+	}
+	baseMint, err := common.FindTokenAddr("WETH", client)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create order for 20 USDC worth of WETH
+	quoteAmount := new(big.Int).SetUint64(20_000_000) // $20 USDC
+	minFillSize := big.NewInt(0)
+	order, err := api_types.NewExternalOrderBuilder().
+		WithQuoteMint(quoteMint).
+		WithBaseMint(baseMint).
+		WithQuoteAmount(api_types.Amount(*quoteAmount)).
+		WithSide("Buy").
+		WithMinFillSize(api_types.Amount(*minFillSize)).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	if err := getQuoteAndSubmit(order, client); err != nil {
+		panic(err)
+	}
+}
+
+func getQuoteAndSubmit(order *api_types.ApiExternalOrder, client *external_match_client.ExternalMatchClient) error {
+	// 1. Get a quote from the relayer
+	fmt.Println("Getting quote...")
+	quote, err := client.GetExternalMatchQuote(order)
+	if err != nil {
+		return err
+	}
+
+	if quote == nil {
+		fmt.Println("No quote found")
+		return nil
+	}
+
+	// 2. Assemble the bundle
+	fmt.Println("Assembling bundle...")
+	options := external_match_client.NewAssembleExternalMatchOptions().WithAllowShared(true)
+	bundle, err := client.AssembleExternalMatchWithOptions(quote, options)
+	if err != nil {
+		return err
+	}
+
+	if bundle == nil {
+		fmt.Println("No bundle found")
+		return nil
+	}
+
+	// 3. Submit the bundle
+	fmt.Println("Submitting bundle...")
+	if err := common.SubmitBundle(*bundle); err != nil {
+		return fmt.Errorf("failed to submit bundle: %w", err)
+	}
+
+	fmt.Print("Bundle submitted successfully!\n\n")
+	return nil
+}


### PR DESCRIPTION
### Purpose
This PR adds the shared bundles flag to the sdk and adds an example using shared bundles.

### Testing
- [x] Tested example in testnet