### PR TITLE
client: external_match_client: migrate to chain-aware URLs

### DIFF
--- a/client/external_match_client/client.go
+++ b/client/external_match_client/client.go
@@ -12,11 +12,11 @@ import (
 
 //nolint:revive
 const (
-	testnetBaseUrl        = "https://testnet.auth-server.renegade.fi:3000"
-	testnetRelayerBaseUrl = "https://testnet.cluster0.renegade.fi:3000"
-	mainnetBaseUrl        = "https://mainnet.auth-server.renegade.fi:3000"
-	mainnetRelayerBaseUrl = "https://mainnet.cluster0.renegade.fi:3000"
-	apiKeyHeader          = "X-Renegade-Api-Key" //nolint:gosec
+	arbitrumSepoliaBaseUrl        = "https://arbitrum-sepolia.auth-server.renegade.fi:3000"
+	arbitrumSepoliaRelayerBaseUrl = "https://arbitrum-sepolia.relayer.renegade.fi:3000"
+	arbitrumOneBaseUrl            = "https://arbitrum-one.auth-server.renegade.fi:3000"
+	arbitrumOneRelayerBaseUrl     = "https://arbitrum-one.relayer.renegade.fi:3000"
+	apiKeyHeader                  = "X-Renegade-Api-Key" //nolint:gosec
 )
 
 // -------------------------
@@ -33,14 +33,28 @@ type ExternalMatchClient struct {
 	relayerHttpClient *client.HttpClient //nolint:revive
 }
 
-// NewTestnetExternalMatchClient creates a new ExternalMatchClient for the testnet
-func NewTestnetExternalMatchClient(apiKey string, apiSecret *wallet.HmacKey) *ExternalMatchClient {
-	return NewExternalMatchClient(testnetBaseUrl, testnetRelayerBaseUrl, apiKey, apiSecret)
+// NewArbitrumSepoliaExternalMatchClient creates a new ExternalMatchClient for the Arbitrum Sepolia network
+func NewArbitrumSepoliaExternalMatchClient(apiKey string, apiSecret *wallet.HmacKey) *ExternalMatchClient {
+	return NewExternalMatchClient(arbitrumSepoliaBaseUrl, arbitrumSepoliaRelayerBaseUrl, apiKey, apiSecret)
 }
 
-// NewMainnetExternalMatchClient creates a new ExternalMatchClient for the mainnet
+// NewTestnetExternalMatchClient creates a new ExternalMatchClient for the Arbitrum Sepolia network
+//
+// Deprecated: Use NewArbitrumSepoliaExternalMatchClient instead
+func NewTestnetExternalMatchClient(apiKey string, apiSecret *wallet.HmacKey) *ExternalMatchClient {
+	return NewArbitrumSepoliaExternalMatchClient(apiKey, apiSecret)
+}
+
+// NewArbitrumOneExternalMatchClient creates a new ExternalMatchClient for the Arbitrum One network
+func NewArbitrumOneExternalMatchClient(apiKey string, apiSecret *wallet.HmacKey) *ExternalMatchClient {
+	return NewExternalMatchClient(arbitrumOneBaseUrl, arbitrumOneRelayerBaseUrl, apiKey, apiSecret)
+}
+
+// NewMainnetExternalMatchClient creates a new ExternalMatchClient for the Arbitrum One network
+//
+// Deprecated: Use NewArbitrumOneExternalMatchClient instead
 func NewMainnetExternalMatchClient(apiKey string, apiSecret *wallet.HmacKey) *ExternalMatchClient {
-	return NewExternalMatchClient(mainnetBaseUrl, mainnetRelayerBaseUrl, apiKey, apiSecret)
+	return NewArbitrumOneExternalMatchClient(apiKey, apiSecret)
 }
 
 // NewExternalMatchClient creates a new ExternalMatchClient with the given base

--- a/examples/02_external_quote_validation/main.go
+++ b/examples/02_external_quote_validation/main.go
@@ -40,7 +40,7 @@ func main() {
 		panic(err)
 	}
 
-	externalMatchClient := external_match_client.NewTestnetExternalMatchClient(apiKey, &apiSecretKey)
+	externalMatchClient := external_match_client.NewArbitrumSepoliaExternalMatchClient(apiKey, &apiSecretKey)
 
 	// Request an external match
 	// We can denominate the order size in either the quote or base token with

--- a/examples/common/client.go
+++ b/examples/common/client.go
@@ -22,7 +22,7 @@ func CreateExternalMatchClient() (*external_match_client.ExternalMatchClient, er
 		return nil, fmt.Errorf("failed to parse API secret: %w", err)
 	}
 
-	return external_match_client.NewTestnetExternalMatchClient(apiKey, &apiSecretKey), nil
+	return external_match_client.NewArbitrumSepoliaExternalMatchClient(apiKey, &apiSecretKey), nil
 }
 
 // FindTokenAddr fetches the address of a token from the relayer


### PR DESCRIPTION
This PR migrates the auth server & relayer URLs used by the external match client to the new, chain-specific namespace. We deprecate the client constructor methods in favor of new, aptly-named ones, as well.

### Testing
- [x] Ran the basic external match example (asserts that auth server is hit)
- [x] Ran the "get fees" example (asserts that relayer is hit)