### PR TITLE
client: external-match-client: Add Base chain configs

### DIFF
--- a/client/external_match_client/client.go
+++ b/client/external_match_client/client.go
@@ -16,6 +16,10 @@ const (
 	arbitrumSepoliaRelayerBaseUrl = "https://arbitrum-sepolia.relayer.renegade.fi:3000"
 	arbitrumOneBaseUrl            = "https://arbitrum-one.auth-server.renegade.fi:3000"
 	arbitrumOneRelayerBaseUrl     = "https://arbitrum-one.relayer.renegade.fi:3000"
+	baseSepoliaBaseUrl            = "https://base-sepolia.auth-server.renegade.fi:3000"
+	baseSepoliaRelayerBaseUrl     = "https://base-sepolia.relayer.renegade.fi:3000"
+	baseMainnetBaseUrl            = "https://base-mainnet.auth-server.renegade.fi:3000"
+	baseMainnetRelayerBaseUrl     = "https://base-mainnet.relayer.renegade.fi:3000"
 	apiKeyHeader                  = "X-Renegade-Api-Key" //nolint:gosec
 )
 
@@ -38,6 +42,11 @@ func NewArbitrumSepoliaExternalMatchClient(apiKey string, apiSecret *wallet.Hmac
 	return NewExternalMatchClient(arbitrumSepoliaBaseUrl, arbitrumSepoliaRelayerBaseUrl, apiKey, apiSecret)
 }
 
+// NewBaseSepoliaExternalMatchClient creates a new ExternalMatchClient for the Base Sepolia network
+func NewBaseSepoliaExternalMatchClient(apiKey string, apiSecret *wallet.HmacKey) *ExternalMatchClient {
+	return NewExternalMatchClient(baseSepoliaBaseUrl, baseSepoliaRelayerBaseUrl, apiKey, apiSecret)
+}
+
 // NewTestnetExternalMatchClient creates a new ExternalMatchClient for the Arbitrum Sepolia network
 //
 // Deprecated: Use NewArbitrumSepoliaExternalMatchClient instead
@@ -48,6 +57,11 @@ func NewTestnetExternalMatchClient(apiKey string, apiSecret *wallet.HmacKey) *Ex
 // NewArbitrumOneExternalMatchClient creates a new ExternalMatchClient for the Arbitrum One network
 func NewArbitrumOneExternalMatchClient(apiKey string, apiSecret *wallet.HmacKey) *ExternalMatchClient {
 	return NewExternalMatchClient(arbitrumOneBaseUrl, arbitrumOneRelayerBaseUrl, apiKey, apiSecret)
+}
+
+// NewBaseMainnetExternalMatchClient creates a new ExternalMatchClient for the Base Mainnet network
+func NewBaseMainnetExternalMatchClient(apiKey string, apiSecret *wallet.HmacKey) *ExternalMatchClient {
+	return NewExternalMatchClient(baseMainnetBaseUrl, baseMainnetRelayerBaseUrl, apiKey, apiSecret)
 }
 
 // NewMainnetExternalMatchClient creates a new ExternalMatchClient for the Arbitrum One network

--- a/examples/03_external_match_with_receiver/main.go
+++ b/examples/03_external_match_with_receiver/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	client, err := common.CreateExternalMatchClient()
+	client, err := common.CreateArbitrumExternalMatchClient()
 	if err != nil {
 		panic(err)
 	}

--- a/examples/04_modify_quoted_order/main.go
+++ b/examples/04_modify_quoted_order/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	client, err := common.CreateExternalMatchClient()
+	client, err := common.CreateArbitrumExternalMatchClient()
 	if err != nil {
 		panic(err)
 	}

--- a/examples/05_native_eth_gas_sponsorship/main.go
+++ b/examples/05_native_eth_gas_sponsorship/main.go
@@ -14,7 +14,7 @@ const (
 )
 
 func main() {
-	client, err := common.CreateExternalMatchClient()
+	client, err := common.CreateArbitrumExternalMatchClient()
 	if err != nil {
 		panic(err)
 	}

--- a/examples/06_exact_amount_out/main.go
+++ b/examples/06_exact_amount_out/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	client, err := common.CreateExternalMatchClient()
+	client, err := common.CreateArbitrumExternalMatchClient()
 	if err != nil {
 		panic(err)
 	}

--- a/examples/07_get_fees/main.go
+++ b/examples/07_get_fees/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	client, err := common.CreateExternalMatchClient()
+	client, err := common.CreateArbitrumExternalMatchClient()
 	if err != nil {
 		panic(err)
 	}

--- a/examples/08_in_kind_gas_sponsorship/main.go
+++ b/examples/08_in_kind_gas_sponsorship/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	client, err := common.CreateExternalMatchClient()
+	client, err := common.CreateArbitrumExternalMatchClient()
 	if err != nil {
 		panic(err)
 	}

--- a/examples/09_shared_bundle/main.go
+++ b/examples/09_shared_bundle/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	client, err := common.CreateExternalMatchClient()
+	client, err := common.CreateArbitrumExternalMatchClient()
 	if err != nil {
 		panic(err)
 	}

--- a/examples/10_base_sepolia_match/main.go
+++ b/examples/10_base_sepolia_match/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	client, err := common.CreateArbitrumExternalMatchClient()
+	client, err := common.CreateBaseExternalMatchClient()
 	if err != nil {
 		panic(err)
 	}
@@ -24,6 +24,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	fmt.Println("quoteMint", quoteMint)
+	fmt.Println("baseMint", baseMint)
 
 	// Create order for 20 USDC worth of WETH
 	quoteAmount := new(big.Int).SetUint64(20_000_000) // $20 USDC
@@ -71,7 +73,7 @@ func getQuoteAndSubmit(order *api_types.ApiExternalOrder, client *external_match
 
 	// 3. Submit the bundle
 	fmt.Println("Submitting bundle...")
-	if err := common.SubmitBundle(*bundle); err != nil {
+	if err := common.SubmitBundleWithChainID(*bundle, common.BaseSepoliaChainID); err != nil {
 		return fmt.Errorf("failed to submit bundle: %w", err)
 	}
 

--- a/examples/common/client.go
+++ b/examples/common/client.go
@@ -9,8 +9,8 @@ import (
 	"github.com/renegade-fi/golang-sdk/wallet"
 )
 
-// CreateExternalMatchClient creates a new external match client using environment variables
-func CreateExternalMatchClient() (*external_match_client.ExternalMatchClient, error) {
+// CreateArbitrumExternalMatchClient creates a new external match client using environment variables
+func CreateArbitrumExternalMatchClient() (*external_match_client.ExternalMatchClient, error) {
 	apiKey := os.Getenv("EXTERNAL_MATCH_KEY")
 	apiSecret := os.Getenv("EXTERNAL_MATCH_SECRET")
 	if apiKey == "" || apiSecret == "" {
@@ -23,6 +23,22 @@ func CreateExternalMatchClient() (*external_match_client.ExternalMatchClient, er
 	}
 
 	return external_match_client.NewArbitrumSepoliaExternalMatchClient(apiKey, &apiSecretKey), nil
+}
+
+// CreateBaseExternalMatchClient creates a new external match client for the Base network
+func CreateBaseExternalMatchClient() (*external_match_client.ExternalMatchClient, error) {
+	apiKey := os.Getenv("EXTERNAL_MATCH_KEY")
+	apiSecret := os.Getenv("EXTERNAL_MATCH_SECRET")
+	if apiKey == "" || apiSecret == "" {
+		return nil, fmt.Errorf("EXTERNAL_MATCH_KEY and EXTERNAL_MATCH_SECRET must be set")
+	}
+
+	apiSecretKey, err := new(wallet.HmacKey).FromBase64String(apiSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse API secret: %w", err)
+	}
+
+	return external_match_client.NewBaseSepoliaExternalMatchClient(apiKey, &apiSecretKey), nil
 }
 
 // FindTokenAddr fetches the address of a token from the relayer

--- a/examples/common/eth.go
+++ b/examples/common/eth.go
@@ -16,11 +16,17 @@ import (
 
 const (
 	// ChainID is the chain ID for the testnet
-	ChainID = 421614
+	ArbitrumSepoliaChainID = 421614
+	BaseSepoliaChainID     = 84532
 )
 
-// SubmitBundle submits the bundle to the sequencer
+// SubmitBundle submits the bundle to the Arbitrum Sepolia network
 func SubmitBundle(bundle external_match_client.ExternalMatchBundle) error {
+	return SubmitBundleWithChainID(bundle, ArbitrumSepoliaChainID)
+}
+
+// SubmitBundle submits the bundle with the given chain ID
+func SubmitBundleWithChainID(bundle external_match_client.ExternalMatchBundle, chainID int64) error {
 	ethClient, err := GetEthClient()
 	if err != nil {
 		return fmt.Errorf("failed to create eth client: %w", err)
@@ -42,7 +48,7 @@ func SubmitBundle(bundle external_match_client.ExternalMatchBundle) error {
 	}
 
 	ethTx := types.NewTx(&types.DynamicFeeTx{
-		ChainID:   big.NewInt(ChainID),
+		ChainID:   big.NewInt(chainID),
 		Nonce:     nonce,
 		GasTipCap: gasPrice,
 		GasFeeCap: new(big.Int).Mul(gasPrice, big.NewInt(2)),
@@ -52,7 +58,7 @@ func SubmitBundle(bundle external_match_client.ExternalMatchBundle) error {
 		Data:      []byte(bundle.SettlementTx.Data),
 	})
 
-	signer := types.LatestSignerForChainID(big.NewInt(ChainID))
+	signer := types.LatestSignerForChainID(big.NewInt(chainID))
 	signedTx, err := types.SignTx(ethTx, signer, privateKey)
 	if err != nil {
 		return fmt.Errorf("failed to sign transaction: %w", err)


### PR DESCRIPTION
### Purpose
This PR adds chain configs for Base Sepolia and mainnet to the external match client.

I also added an example which creates an external match against Base sepolia.

### Testing
- [x] Examples pass