### PR TITLE
client: external-match-client: Un-deprecate direct matches

### DIFF
--- a/client/external_match_client/client.go
+++ b/client/external_match_client/client.go
@@ -228,8 +228,6 @@ func (c *ExternalMatchClient) AssembleExternalMatchWithOptions(
 
 // GetExternalMatchBundle requests an external match bundle from the relayer
 // returns nil if no match is found
-//
-// Deprecated: Use the quote + assemble methods instead
 func (c *ExternalMatchClient) GetExternalMatchBundle(
 	request *api_types.ApiExternalOrder,
 ) (*ExternalMatchBundle, error) {
@@ -238,15 +236,14 @@ func (c *ExternalMatchClient) GetExternalMatchBundle(
 
 // GetExternalMatchBundleWithReceiver requests an external match bundle from the relayer
 // returns nil if no match is found
-//
-// Deprecated: Use the quote + assemble methods instead
 func (c *ExternalMatchClient) GetExternalMatchBundleWithReceiver(
 	request *api_types.ApiExternalOrder,
 	receiverAddress *string,
 ) (*ExternalMatchBundle, error) {
 	options := &ExternalMatchOptions{
 		AssembleExternalMatchOptions: AssembleExternalMatchOptions{
-			ReceiverAddress: receiverAddress,
+			ReceiverAddress:       receiverAddress,
+			RequestGasSponsorship: true, // default to true
 		},
 	}
 	return c.GetExternalMatchBundleWithOptions(request, options)
@@ -254,8 +251,6 @@ func (c *ExternalMatchClient) GetExternalMatchBundleWithReceiver(
 
 // GetExternalMatchBundleWithOptions requests an external match bundle from the relayer with the given options
 // returns nil if no match is found
-//
-// Deprecated: Use the quote + assemble methods instead
 func (c *ExternalMatchClient) GetExternalMatchBundleWithOptions(
 	request *api_types.ApiExternalOrder,
 	options *ExternalMatchOptions,

--- a/client/external_match_client/types.go
+++ b/client/external_match_client/types.go
@@ -147,12 +147,7 @@ func NewExternalQuoteOptions() *ExternalQuoteOptions {
 type AssembleExternalMatchOptions struct {
 	ReceiverAddress *string
 	DoGasEstimation bool
-	// AllowShared is a flag to allow the assembly of a shared quote
-	//
-	// If true, the relayer will not enforce exclusive access to the bundle returned in the
-	// assemble step. I.e. the relayer may send the same bundle to another client.
-	//
-	// This affords the client a much higher rate limit
+	// Deprecated: Shared bundles are no longer supported
 	AllowShared  bool
 	UpdatedOrder *api_types.ApiExternalOrder
 	// RequestGasSponsorship is a flag to request gas sponsorship for the settlement tx
@@ -160,8 +155,6 @@ type AssembleExternalMatchOptions struct {
 	// This is subject to rate limit by the auth server, but if approved will refund the gas spent
 	// on the settlement tx to the address specified in `GasRefundAddress`. If no refund address is
 	// specified, the refund is directed to `tx.origin`
-	//
-	// Deprecated: Request gas sponsorship when requesting a quote
 	RequestGasSponsorship bool
 	// GasRefundAddress is the address to refund the gas to
 	//
@@ -227,15 +220,14 @@ func (o *AssembleExternalMatchOptions) BuildRequestPath() string {
 // NewAssembleExternalMatchOptions creates a new AssembleExternalMatchOptions with default values
 func NewAssembleExternalMatchOptions() *AssembleExternalMatchOptions {
 	return &AssembleExternalMatchOptions{
-		ReceiverAddress: nil,
-		DoGasEstimation: false,
-		UpdatedOrder:    nil,
+		ReceiverAddress:       nil,
+		DoGasEstimation:       false,
+		UpdatedOrder:          nil,
+		RequestGasSponsorship: true,
 	}
 }
 
 // ExternalMatchOptions represents the options for an external match request
-//
-// Deprecated: Use AssembleExternalMatchOptions instead
 type ExternalMatchOptions struct {
 	AssembleExternalMatchOptions
 }

--- a/examples/11_direct_match/main.go
+++ b/examples/11_direct_match/main.go
@@ -1,0 +1,70 @@
+// Package main demonstrates retrieving and submitting an external match bundle directly.
+package main
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/renegade-fi/golang-sdk/client/api_types"
+	"github.com/renegade-fi/golang-sdk/client/external_match_client"
+	"github.com/renegade-fi/golang-sdk/examples/common"
+)
+
+func main() {
+	client, err := common.CreateArbitrumExternalMatchClient()
+	if err != nil {
+		panic(err)
+	}
+
+	// Fetch token mappings from the relayer
+	quoteMint, err := common.FindTokenAddr("USDC", client)
+	if err != nil {
+		panic(err)
+	}
+	baseMint, err := common.FindTokenAddr("WETH", client)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create order for 20 USDC worth of WETH
+	quoteAmount := new(big.Int).SetUint64(20_000_000) // $20 USDC
+	minFillSize := big.NewInt(0)
+	order, err := api_types.NewExternalOrderBuilder().
+		WithQuoteMint(quoteMint).
+		WithBaseMint(baseMint).
+		WithQuoteAmount(api_types.Amount(*quoteAmount)).
+		WithSide("Buy").
+		WithMinFillSize(api_types.Amount(*minFillSize)).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	if err := getMatchAndSubmit(order, client); err != nil {
+		panic(err)
+	}
+}
+
+func getMatchAndSubmit(order *api_types.ApiExternalOrder, client *external_match_client.ExternalMatchClient) error {
+	// 1. Rather than quote + assemble as in other examples, we directly request
+	// 	a bundle from the relayer
+	fmt.Println("Fetching bundle...")
+	bundle, err := client.GetExternalMatchBundle(order)
+	if err != nil {
+		return err
+	}
+
+	if bundle == nil {
+		fmt.Println("No bundle found")
+		return nil
+	}
+
+	// 2. Submit the bundle
+	fmt.Println("Submitting bundle...")
+	if err := common.SubmitBundle(*bundle); err != nil {
+		return fmt.Errorf("failed to submit bundle: %w", err)
+	}
+
+	fmt.Print("Bundle submitted successfully!\n\n")
+	return nil
+}


### PR DESCRIPTION
### Purpose
This PR un-deprecates direct matches in the golang client. They now have a legitimate use case and are not bottlenecked by strict rate limits.

I also enabled gas sponsorship by default on the direct match paths.

### Testing
- [x] Tested example locally