### PR TITLE
fix: type handling for Amount and Bundle in SDK

### DIFF
--- a/examples/11_direct_match/main.go
+++ b/examples/11_direct_match/main.go
@@ -32,9 +32,9 @@ func main() {
 	order, err := api_types.NewExternalOrderBuilder().
 		WithQuoteMint(quoteMint).
 		WithBaseMint(baseMint).
-		WithQuoteAmount(api_types.Amount(*quoteAmount)).
+		WithQuoteAmount(quoteAmount).
 		WithSide("Buy").
-		WithMinFillSize(api_types.Amount(*minFillSize)).
+		WithMinFillSize(minFillSize).
 		Build()
 	if err != nil {
 		panic(err)
@@ -61,7 +61,7 @@ func getMatchAndSubmit(order *api_types.ApiExternalOrder, client *external_match
 
 	// 2. Submit the bundle
 	fmt.Println("Submitting bundle...")
-	if err := common.SubmitBundle(*bundle); err != nil {
+	if err := common.SubmitBundle(bundle); err != nil {
 		return fmt.Errorf("failed to submit bundle: %w", err)
 	}
 


### PR DESCRIPTION
updated `WithQuoteAmount(quoteAmount)` and `WithMinFillSize(minFillSize)` to pass a `*big.Int` pointer to `api_types.Amount` as expected, instead of dereferencing the struct.

similarly, `common.SubmitBundle(bundle)` now passes a pointer to the bundle, matching the function signature.

these changes prevent potential panics and ensure proper type handling in the SDK.