### PR TITLE
Feat: add `gas` field to `SettlementTransaction`

### DIFF
--- a/client/api_types/api_external_match.go
+++ b/client/api_types/api_external_match.go
@@ -176,6 +176,7 @@ type ApiSettlementTransaction struct { //nolint:revive
 	To    string `json:"to"`
 	Data  string `json:"data"`
 	Value string `json:"value"`
+	Gas   string `json:"gas"`
 }
 
 // ApiExternalMatchFee represents the fees for a given asset in external matches

--- a/client/external_match_client/types.go
+++ b/client/external_match_client/types.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	geth_common "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/renegade-fi/golang-sdk/client/api_types"
 )
@@ -36,6 +37,7 @@ type SettlementTransaction struct {
 	To    geth_common.Address
 	Data  []byte
 	Value *big.Int
+	Gas   uint64
 }
 
 // toSettlementTransaction converts an ApiSettlementTransaction to a SettlementTransaction
@@ -46,11 +48,22 @@ func toSettlementTransaction(tx *api_types.ApiSettlementTransaction) *Settlement
 	valueBytes := geth_common.FromHex(tx.Value)
 	value := big.NewInt(0).SetBytes(valueBytes)
 
+	// Parse gas from hex string
+	var gas uint64
+	if tx.Gas != "" {
+		decoded, err := hexutil.DecodeUint64(tx.Gas)
+		if err == nil {
+			gas = decoded
+		}
+		// If decode fails, gas remains 0
+	}
+
 	return &SettlementTransaction{
 		Type:  tx.Type,
 		To:    to,
 		Data:  data,
 		Value: value,
+		Gas:   gas,
 	}
 }
 

--- a/examples/common/eth.go
+++ b/examples/common/eth.go
@@ -52,7 +52,7 @@ func SubmitBundleWithChainID(bundle external_match_client.ExternalMatchBundle, c
 		Nonce:     nonce,
 		GasTipCap: gasPrice,
 		GasFeeCap: new(big.Int).Mul(gasPrice, big.NewInt(2)),
-		Gas:       uint64(10_000_000),
+		Gas:       getGasLimit(bundle.SettlementTx.Gas),
 		To:        &bundle.SettlementTx.To,
 		Value:     bundle.SettlementTx.Value,
 		Data:      []byte(bundle.SettlementTx.Data),
@@ -90,4 +90,15 @@ func GetPrivateKey() (*ecdsa.PrivateKey, error) {
 	}
 
 	return crypto.HexToECDSA(privKeyHex)
+}
+
+// getGasLimit returns the gas limit to use for the transaction
+// If the bundle contains a gas estimate, it uses that value with 20% buffer
+// Otherwise, it returns a default fallback value
+func getGasLimit(estimatedGas uint64) uint64 {
+	if estimatedGas > 0 {
+		return estimatedGas * 120 / 100
+	}
+	// Fallback to a safe default if no gas estimate is provided
+	return uint64(10_000_000)
 }


### PR DESCRIPTION
Adds the `Gas` field to both `ApiSettlementTransaction` and `SettlementTransaction` types to match the [Node.js SDK implementation](https://github.com/renegade-fi/typescript-sdk/blob/main/packages/core/src/types/externalMatch.ts#L28).

The Renegade API returns a `gas` field (as a hex string like `"0x3d0900"`) in the settlement transaction, but the Go SDK was not exposing it. This PR:

1. Adds `Gas` field to `ApiSettlementTransaction` (hex string, optional)
2. Adds `Gas` field to `SettlementTransaction` (uint64)
3. Updates `toSettlementTransaction()` to parse the hex gas value
4. Updates an example to use an accurate gasLimit

This allows users to get accurate gas estimates for external match settlements instead of using hardcoded defaults.

**Matches Node.js SDK:** The Node.js SDK includes this field in `ExternalSettlementTx`
https://github.com/renegade-fi/typescript-sdk/blob/main/packages/core/src/types/externalMatch.ts#L28