### PR TITLE
feat(external match client): v2 external match client w/ backwards-compatibility shims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 **/.DS_Store
 
 **/.env*
+AGENTS*.md
+CLAUDE*.md

--- a/client/api_types/api_external_match.go
+++ b/client/api_types/api_external_match.go
@@ -148,8 +148,35 @@ type ApiExternalQuote struct { //nolint:revive
 type ApiSignedQuote struct { //nolint:revive
 	Quote     ApiExternalQuote `json:"quote"`
 	Signature string           `json:"signature"`
+	Deadline  uint64           `json:"deadline"`
 	// The signed gas sponsorship info, if sponsorship was requested
 	GasSponsorshipInfo *ApiSignedGasSponsorshipInfo
+	// innerV2Quote stores the original v2 signed quote for round-tripping.
+	// The server's signature is over the v2 format, so we cannot reconstruct
+	// a valid signed v2 quote from v1 fields alone.
+	innerV2Quote *ApiSignedQuoteV2
+}
+
+// NewApiSignedQuote creates an ApiSignedQuote with the inner v2 quote for round-tripping
+func NewApiSignedQuote(
+	quote ApiExternalQuote,
+	signature string,
+	deadline uint64,
+	gasSponsorshipInfo *ApiSignedGasSponsorshipInfo,
+	innerV2Quote *ApiSignedQuoteV2,
+) *ApiSignedQuote {
+	return &ApiSignedQuote{
+		Quote:              quote,
+		Signature:          signature,
+		Deadline:           deadline,
+		GasSponsorshipInfo: gasSponsorshipInfo,
+		innerV2Quote:       innerV2Quote,
+	}
+}
+
+// InnerV2Quote returns the stored v2 signed quote for round-tripping
+func (q *ApiSignedQuote) InnerV2Quote() *ApiSignedQuoteV2 {
+	return q.innerV2Quote
 }
 
 // ApiExternalMatchBundle contains a match and a transaction that the client can submit on-chain

--- a/client/api_types/api_external_match_v2.go
+++ b/client/api_types/api_external_match_v2.go
@@ -1,0 +1,511 @@
+package api_types //nolint:revive
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strconv"
+)
+
+// ---------------------
+// | V2 Route Constants |
+// ---------------------
+
+//nolint:revive
+const (
+	// GetMarketsPath is the path for fetching all tradable markets
+	GetMarketsPath = "/v2/markets"
+	// GetMarketsDepthPath is the path for fetching depth of all markets
+	GetMarketsDepthPath = "/v2/markets/depth"
+	// GetMarketDepthByMintPath is the path for fetching depth of a specific market
+	// Use fmt.Sprintf with the mint address
+	GetMarketDepthByMintPath = "/v2/markets/%s/depth"
+	// GetQuoteV2Path is the path for requesting a v2 quote
+	GetQuoteV2Path = "/v2/external-matches/get-quote"
+	// AssembleMatchBundleV2Path is the path for assembling a v2 match bundle
+	AssembleMatchBundleV2Path = "/v2/external-matches/assemble-match-bundle"
+	// GetExchangeMetadataPath is the path for fetching exchange metadata
+	GetExchangeMetadataPath = "/v2/metadata/exchange"
+)
+
+// BuildGetMarketDepthByMintPath builds the path for fetching the market depth for a specific mint
+func BuildGetMarketDepthByMintPath(mint string) string {
+	return fmt.Sprintf(GetMarketDepthByMintPath, mint)
+}
+
+// -------------------------
+// | Serialization Helpers |
+// -------------------------
+
+// StringAmount is a big.Int wrapper that marshals/unmarshals as a quoted JSON string.
+// This is needed because v2 wire format uses JSON strings for amounts (e.g. "100")
+// while v1's Amount type marshals as bare numbers.
+type StringAmount big.Int
+
+// NewStringAmount creates a new StringAmount from an int64
+func NewStringAmount(i int64) StringAmount {
+	return StringAmount(*big.NewInt(i))
+}
+
+// NewStringAmountFromBigInt creates a new StringAmount from a *big.Int
+func NewStringAmountFromBigInt(i *big.Int) StringAmount {
+	return StringAmount(*i)
+}
+
+// ToBigInt converts a StringAmount to a *big.Int
+func (a *StringAmount) ToBigInt() *big.Int {
+	return (*big.Int)(a)
+}
+
+// IsZero returns true if the amount is zero
+func (a *StringAmount) IsZero() bool {
+	return (*big.Int)(a).Sign() == 0
+}
+
+// MarshalJSON marshals the StringAmount as a quoted JSON string
+func (a StringAmount) MarshalJSON() ([]byte, error) {
+	s := (*big.Int)(&a).String()
+	return json.Marshal(s)
+}
+
+// UnmarshalJSON unmarshals the StringAmount from a quoted JSON string
+func (a *StringAmount) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	i, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return fmt.Errorf("invalid StringAmount: %s", s)
+	}
+	*a = StringAmount(*i)
+	return nil
+}
+
+// StringFloat is a float64 wrapper that marshals/unmarshals as a quoted JSON string.
+// Used for fields like DepthSide.TotalQuantityUSD.
+type StringFloat float64
+
+// MarshalJSON marshals the StringFloat as a quoted JSON string
+func (f StringFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	return json.Marshal(s)
+}
+
+// UnmarshalJSON unmarshals the StringFloat from a quoted JSON string
+func (f *StringFloat) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	val, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return fmt.Errorf("invalid StringFloat: %s", s)
+	}
+	*f = StringFloat(val)
+	return nil
+}
+
+// ----------------
+// | FixedPoint   |
+// ----------------
+
+// fixedPointPrecisionBits is the number of bits used for fixed-point precision
+const fixedPointPrecisionBits = 63
+
+// fixedPointPrecisionShift returns 2^63 as a *big.Int
+func fixedPointPrecisionShift() *big.Int {
+	shift := new(big.Int).SetUint64(1)
+	return shift.Lsh(shift, fixedPointPrecisionBits)
+}
+
+// FixedPoint is a fixed-point number with 63-bit precision.
+// The value represents the number multiplied by 2^63.
+type FixedPoint struct {
+	Value *big.Int
+}
+
+// NewFixedPoint creates a new FixedPoint from a *big.Int value
+func NewFixedPoint(value *big.Int) FixedPoint {
+	return FixedPoint{Value: value}
+}
+
+// FloorMulInt multiplies this fixed-point by an integer amount and returns the floor.
+// Result = (value * amount) / 2^63
+func (fp *FixedPoint) FloorMulInt(amount *big.Int) *big.Int {
+	product := new(big.Int).Mul(fp.Value, amount)
+	return new(big.Int).Div(product, fixedPointPrecisionShift())
+}
+
+// CeilDivInt divides an amount by this fixed-point and returns the ceiling.
+// Result = ceil(amount * 2^63 / value)
+func CeilDivInt(amount *big.Int, fp *FixedPoint) *big.Int {
+	numerator := new(big.Int).Mul(amount, fixedPointPrecisionShift())
+	quotient := new(big.Int)
+	remainder := new(big.Int)
+	quotient.DivMod(numerator, fp.Value, remainder)
+	if remainder.Sign() > 0 {
+		quotient.Add(quotient, big.NewInt(1))
+	}
+	return quotient
+}
+
+// ToF64 converts the fixed-point number to a float64 approximation.
+// Result = value / 2^63
+func (fp *FixedPoint) ToF64() float64 {
+	valueFloat := new(big.Float).SetInt(fp.Value)
+	shiftFloat := new(big.Float).SetInt(fixedPointPrecisionShift())
+	result := new(big.Float).Quo(valueFloat, shiftFloat)
+	f, _ := result.Float64()
+	return f
+}
+
+// Add adds two fixed-point numbers
+func (fp *FixedPoint) Add(other *FixedPoint) FixedPoint {
+	sum := new(big.Int).Add(fp.Value, other.Value)
+	return FixedPoint{Value: sum}
+}
+
+// MarshalJSON serializes the FixedPoint as a quoted decimal string
+func (fp FixedPoint) MarshalJSON() ([]byte, error) {
+	s := fp.Value.String()
+	return json.Marshal(s)
+}
+
+// UnmarshalJSON deserializes the FixedPoint from a quoted decimal string
+func (fp *FixedPoint) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	i, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return fmt.Errorf("invalid FixedPoint: %s", s)
+	}
+	fp.Value = i
+	return nil
+}
+
+// ---------------
+// | Order Types |
+// ---------------
+
+// ApiExternalOrderV2 is a v2 external order using input/output semantics
+type ApiExternalOrderV2 struct { //nolint:revive
+	// The mint (erc20 address) of the input token
+	InputMint string `json:"input_mint"`
+	// The mint (erc20 address) of the output token
+	OutputMint string `json:"output_mint"`
+	// The input amount
+	InputAmount StringAmount `json:"input_amount"`
+	// The output amount
+	OutputAmount StringAmount `json:"output_amount"`
+	// Whether to use exact output amount
+	UseExactOutputAmount bool `json:"use_exact_output_amount"`
+	// The minimum fill size
+	MinFillSize StringAmount `json:"min_fill_size"`
+}
+
+// ApiExternalOrderBuilderV2 helps construct ApiExternalOrderV2 with validation
+type ApiExternalOrderBuilderV2 struct { //nolint:revive
+	order ApiExternalOrderV2
+}
+
+// NewExternalOrderBuilderV2 creates a new v2 order builder
+func NewExternalOrderBuilderV2() *ApiExternalOrderBuilderV2 {
+	return &ApiExternalOrderBuilderV2{
+		order: ApiExternalOrderV2{
+			InputAmount:  NewStringAmount(0),
+			OutputAmount: NewStringAmount(0),
+			MinFillSize:  NewStringAmount(0),
+		},
+	}
+}
+
+// WithInputMint sets the input mint
+func (b *ApiExternalOrderBuilderV2) WithInputMint(mint string) *ApiExternalOrderBuilderV2 {
+	b.order.InputMint = mint
+	return b
+}
+
+// WithOutputMint sets the output mint
+func (b *ApiExternalOrderBuilderV2) WithOutputMint(mint string) *ApiExternalOrderBuilderV2 {
+	b.order.OutputMint = mint
+	return b
+}
+
+// WithInputAmount sets the input amount
+func (b *ApiExternalOrderBuilderV2) WithInputAmount(amount StringAmount) *ApiExternalOrderBuilderV2 {
+	b.order.InputAmount = amount
+	return b
+}
+
+// WithOutputAmount sets the output amount
+func (b *ApiExternalOrderBuilderV2) WithOutputAmount(amount StringAmount) *ApiExternalOrderBuilderV2 {
+	b.order.OutputAmount = amount
+	return b
+}
+
+// WithExactOutputAmount sets the use exact output amount flag
+func (b *ApiExternalOrderBuilderV2) WithExactOutputAmount(exact bool) *ApiExternalOrderBuilderV2 {
+	b.order.UseExactOutputAmount = exact
+	return b
+}
+
+// WithMinFillSize sets the minimum fill size
+func (b *ApiExternalOrderBuilderV2) WithMinFillSize(size StringAmount) *ApiExternalOrderBuilderV2 {
+	b.order.MinFillSize = size
+	return b
+}
+
+// Build validates and returns the ApiExternalOrderV2
+func (b *ApiExternalOrderBuilderV2) Build() (*ApiExternalOrderV2, error) {
+	if b.order.InputMint == "" {
+		return nil, errors.New("input mint is required")
+	}
+	if b.order.OutputMint == "" {
+		return nil, errors.New("output mint is required")
+	}
+	if b.order.InputAmount.IsZero() && b.order.OutputAmount.IsZero() {
+		return nil, errors.New("one of input_amount or output_amount must be set")
+	}
+	return &b.order, nil
+}
+
+// ----------------------
+// | Match Result Types |
+// ----------------------
+
+// ApiTimestampedPriceFp is a timestamped price with full fixed-point precision
+type ApiTimestampedPriceFp struct { //nolint:revive
+	Price     FixedPoint `json:"price"`
+	Timestamp uint64     `json:"timestamp"`
+}
+
+// ApiExternalMatchResultV2 is the v2 match result with input/output semantics
+type ApiExternalMatchResultV2 struct { //nolint:revive
+	InputMint    string                `json:"input_mint"`
+	OutputMint   string                `json:"output_mint"`
+	InputAmount  StringAmount          `json:"input_amount"`
+	OutputAmount StringAmount          `json:"output_amount"`
+	PriceFp      ApiTimestampedPriceFp `json:"price_fp"`
+}
+
+// ApiBoundedMatchResultV2 is a bounded match result for malleable matches
+type ApiBoundedMatchResultV2 struct { //nolint:revive
+	InputMint      string       `json:"input_mint"`
+	OutputMint     string       `json:"output_mint"`
+	PriceFp        FixedPoint   `json:"price_fp"`
+	MinInputAmount StringAmount `json:"min_input_amount"`
+	MaxInputAmount StringAmount `json:"max_input_amount"`
+}
+
+// ---------------
+// | Fee Types   |
+// ---------------
+
+// FeeTake represents the fee amounts paid to the relayer and protocol
+type FeeTake struct {
+	RelayerFee  StringAmount `json:"relayer_fee"`
+	ProtocolFee StringAmount `json:"protocol_fee"`
+}
+
+// Total returns the total fee
+func (f *FeeTake) Total() *big.Int {
+	return new(big.Int).Add(f.RelayerFee.ToBigInt(), f.ProtocolFee.ToBigInt())
+}
+
+// FeeTakeRate represents the fee rates for relayer and protocol
+type FeeTakeRate struct {
+	RelayerFeeRate  FixedPoint `json:"relayer_fee_rate"`
+	ProtocolFeeRate FixedPoint `json:"protocol_fee_rate"`
+}
+
+// Total returns the total fee rate
+func (f *FeeTakeRate) Total() FixedPoint {
+	return f.RelayerFeeRate.Add(&f.ProtocolFeeRate)
+}
+
+// --------------------------
+// | Asset Transfer (V2)    |
+// --------------------------
+
+// ApiExternalAssetTransferV2 represents a v2 asset transfer with string amounts
+type ApiExternalAssetTransferV2 struct { //nolint:revive
+	Mint   string       `json:"mint"`
+	Amount StringAmount `json:"amount"`
+}
+
+// ---------------
+// | Quote Types |
+// ---------------
+
+// ApiExternalQuoteV2 is a v2 quote from the relayer
+type ApiExternalQuoteV2 struct { //nolint:revive
+	Order       ApiExternalOrderV2         `json:"order"`
+	MatchResult ApiExternalMatchResultV2   `json:"match_result"`
+	Fees        FeeTake                    `json:"fees"`
+	Send        ApiExternalAssetTransferV2 `json:"send"`
+	Receive     ApiExternalAssetTransferV2 `json:"receive"`
+	Price       TimestampedPrice           `json:"price"`
+	Timestamp   uint64                     `json:"timestamp"`
+}
+
+// ApiSignedQuoteV2 is a signed v2 quote from the relayer
+type ApiSignedQuoteV2 struct { //nolint:revive
+	Quote     ApiExternalQuoteV2 `json:"quote"`
+	Signature string             `json:"signature"`
+	Deadline  uint64             `json:"deadline"`
+}
+
+// ----------------
+// | Bundle Types |
+// ----------------
+
+// ApiSettlementTransactionV2 is the v2 settlement tx format matching alloy's TransactionRequest.
+// Uses "input" instead of "data" for the calldata field, and fields are optional.
+type ApiSettlementTransactionV2 struct { //nolint:revive
+	To    *string `json:"to,omitempty"`
+	Input string  `json:"input,omitempty"`
+	Value *string `json:"value,omitempty"`
+	Gas   *string `json:"gas,omitempty"`
+}
+
+// ToV1 converts a v2 settlement tx to the v1 wire format
+func (tx *ApiSettlementTransactionV2) ToV1() ApiSettlementTransaction {
+	to := ""
+	if tx.To != nil {
+		to = *tx.To
+	}
+	value := ""
+	if tx.Value != nil {
+		value = *tx.Value
+	}
+	gas := ""
+	if tx.Gas != nil {
+		gas = *tx.Gas
+	}
+	return ApiSettlementTransaction{
+		To:    to,
+		Data:  tx.Input,
+		Value: value,
+		Gas:   gas,
+	}
+}
+
+// MalleableAtomicMatchApiBundleV2 contains a malleable match bundle
+type MalleableAtomicMatchApiBundleV2 struct { //nolint:revive
+	MatchResult  ApiBoundedMatchResultV2    `json:"match_result"`
+	FeeRates     FeeTakeRate                `json:"fee_rates"`
+	MaxReceive   ApiExternalAssetTransferV2 `json:"max_receive"`
+	MinReceive   ApiExternalAssetTransferV2 `json:"min_receive"`
+	MaxSend      ApiExternalAssetTransferV2 `json:"max_send"`
+	MinSend      ApiExternalAssetTransferV2 `json:"min_send"`
+	SettlementTx ApiSettlementTransactionV2 `json:"settlement_tx"`
+	Deadline     uint64                     `json:"deadline"`
+}
+
+// -------------------------
+// | Request/Response Types |
+// -------------------------
+
+// ExternalQuoteRequestV2 is the request body for a v2 quote
+type ExternalQuoteRequestV2 struct {
+	ExternalOrder ApiExternalOrderV2 `json:"external_order"`
+}
+
+// ExternalQuoteResponseV2 is the response body for a v2 quote
+type ExternalQuoteResponseV2 struct {
+	SignedQuote        ApiSignedQuoteV2       `json:"signed_quote"`
+	GasSponsorshipInfo *ApiGasSponsorshipInfo `json:"gas_sponsorship_info,omitempty"`
+}
+
+// AssemblyType represents the tagged union for the assembly request order field.
+// Uses flat struct with omitempty to produce correct JSON for either variant.
+type AssemblyType struct {
+	Type          string              `json:"type"`                     // "quoted-order" or "direct-order"
+	SignedQuote   *ApiSignedQuoteV2   `json:"signed_quote,omitempty"`   // for quoted-order
+	UpdatedOrder  *ApiExternalOrderV2 `json:"updated_order,omitempty"`  // for quoted-order (optional)
+	ExternalOrder *ApiExternalOrderV2 `json:"external_order,omitempty"` // for direct-order
+}
+
+// NewQuotedOrderAssembly creates an AssemblyType for a quoted order
+func NewQuotedOrderAssembly(quote *ApiSignedQuoteV2, updatedOrder *ApiExternalOrderV2) AssemblyType {
+	return AssemblyType{
+		Type:         "quoted-order",
+		SignedQuote:  quote,
+		UpdatedOrder: updatedOrder,
+	}
+}
+
+// NewDirectOrderAssembly creates an AssemblyType for a direct order
+func NewDirectOrderAssembly(order *ApiExternalOrderV2) AssemblyType {
+	return AssemblyType{
+		Type:          "direct-order",
+		ExternalOrder: order,
+	}
+}
+
+// AssembleExternalMatchRequestV2 is the request body for a v2 assembly
+type AssembleExternalMatchRequestV2 struct {
+	DoGasEstimation bool         `json:"do_gas_estimation"`
+	ReceiverAddress *string      `json:"receiver_address,omitempty"`
+	Order           AssemblyType `json:"order"`
+}
+
+// ExternalMatchResponseV2 is the response body for a v2 match
+type ExternalMatchResponseV2 struct {
+	MatchBundle        MalleableAtomicMatchApiBundleV2 `json:"match_bundle"`
+	GasSponsorshipInfo *ApiGasSponsorshipInfo          `json:"gas_sponsorship_info,omitempty"`
+}
+
+// ----------------------
+// | Market Data Types  |
+// ----------------------
+
+// MarketInfo represents information about a tradable market
+type MarketInfo struct {
+	Base                  ApiToken         `json:"base"`
+	Quote                 ApiToken         `json:"quote"`
+	Price                 TimestampedPrice `json:"price"`
+	InternalMatchFeeRates FeeTakeRate      `json:"internal_match_fee_rates"`
+	ExternalMatchFeeRates FeeTakeRate      `json:"external_match_fee_rates"`
+}
+
+// DepthSide represents the liquidity depth for one side of a market
+type DepthSide struct {
+	TotalQuantity    StringAmount `json:"total_quantity"`
+	TotalQuantityUSD StringFloat  `json:"total_quantity_usd"`
+}
+
+// MarketDepth represents the full depth of a market
+type MarketDepth struct {
+	Market MarketInfo `json:"market"`
+	Buy    DepthSide  `json:"buy"`
+	Sell   DepthSide  `json:"sell"`
+}
+
+// GetMarketsResponse is the response for the GetMarkets endpoint
+type GetMarketsResponse struct {
+	Markets []MarketInfo `json:"markets"`
+}
+
+// GetMarketDepthByMintResponse is the response for the GetMarketDepthByMint endpoint
+type GetMarketDepthByMintResponse struct {
+	MarketDepth MarketDepth `json:"market_depth"`
+}
+
+// GetMarketDepthsResponse is the response for the GetMarketDepths endpoint
+type GetMarketDepthsResponse struct {
+	MarketDepths []MarketDepth `json:"market_depths"`
+}
+
+// ExchangeMetadataResponse is the response for the GetExchangeMetadata endpoint
+type ExchangeMetadataResponse struct {
+	ChainID                   uint64     `json:"chain_id"`
+	SettlementContractAddress string     `json:"settlement_contract_address"`
+	ExecutorAddress           string     `json:"executor_address"`
+	RelayerFeeRecipient       string     `json:"relayer_fee_recipient"`
+	SupportedTokens           []ApiToken `json:"supported_tokens"`
+}

--- a/client/external_match_client/v1_conversions.go
+++ b/client/external_match_client/v1_conversions.go
@@ -1,0 +1,394 @@
+package external_match_client //nolint:revive
+
+import (
+	"fmt"
+	"math/big"
+	"strconv"
+
+	geth_common "github.com/ethereum/go-ethereum/common"
+
+	"github.com/renegade-fi/golang-sdk/client/api_types"
+)
+
+// ---------------------
+// | Order Conversions |
+// ---------------------
+
+// v1OrderToV2 converts a v1 ApiExternalOrder to a v2 ApiExternalOrderV2
+func v1OrderToV2(order *api_types.ApiExternalOrder) api_types.ApiExternalOrderV2 {
+	switch order.Side {
+	case "Buy":
+		// Buy: input=quote, output=base
+		var inputAmount, outputAmount api_types.StringAmount
+		var useExactOutput bool
+		quoteAmt := (*big.Int)(&order.QuoteAmount)
+		baseAmt := (*big.Int)(&order.BaseAmount)
+		exactBaseOut := (*big.Int)(&order.ExactBaseAmountOutput)
+		exactQuoteOut := (*big.Int)(&order.ExactQuoteAmountOutput)
+
+		if quoteAmt.Sign() != 0 {
+			inputAmount = api_types.NewStringAmountFromBigInt(quoteAmt)
+			outputAmount = api_types.NewStringAmount(0)
+			useExactOutput = false
+		} else if baseAmt.Sign() != 0 {
+			inputAmount = api_types.NewStringAmount(0)
+			outputAmount = api_types.NewStringAmountFromBigInt(baseAmt)
+			useExactOutput = false
+		} else if exactBaseOut.Sign() != 0 {
+			inputAmount = api_types.NewStringAmount(0)
+			outputAmount = api_types.NewStringAmountFromBigInt(exactBaseOut)
+			useExactOutput = true
+		} else {
+			inputAmount = api_types.NewStringAmountFromBigInt(exactQuoteOut)
+			outputAmount = api_types.NewStringAmount(0)
+			useExactOutput = true
+		}
+
+		return api_types.ApiExternalOrderV2{
+			InputMint:            order.QuoteMint,
+			OutputMint:           order.BaseMint,
+			InputAmount:          inputAmount,
+			OutputAmount:         outputAmount,
+			UseExactOutputAmount: useExactOutput,
+			MinFillSize:          api_types.NewStringAmountFromBigInt((*big.Int)(&order.MinFillSize)),
+		}
+
+	default: // Sell
+		// Sell: input=base, output=quote
+		var inputAmount, outputAmount api_types.StringAmount
+		var useExactOutput bool
+		baseAmt := (*big.Int)(&order.BaseAmount)
+		quoteAmt := (*big.Int)(&order.QuoteAmount)
+		exactQuoteOut := (*big.Int)(&order.ExactQuoteAmountOutput)
+		exactBaseOut := (*big.Int)(&order.ExactBaseAmountOutput)
+
+		if baseAmt.Sign() != 0 {
+			inputAmount = api_types.NewStringAmountFromBigInt(baseAmt)
+			outputAmount = api_types.NewStringAmount(0)
+			useExactOutput = false
+		} else if quoteAmt.Sign() != 0 {
+			inputAmount = api_types.NewStringAmount(0)
+			outputAmount = api_types.NewStringAmountFromBigInt(quoteAmt)
+			useExactOutput = false
+		} else if exactQuoteOut.Sign() != 0 {
+			inputAmount = api_types.NewStringAmount(0)
+			outputAmount = api_types.NewStringAmountFromBigInt(exactQuoteOut)
+			useExactOutput = true
+		} else {
+			inputAmount = api_types.NewStringAmountFromBigInt(exactBaseOut)
+			outputAmount = api_types.NewStringAmount(0)
+			useExactOutput = true
+		}
+
+		return api_types.ApiExternalOrderV2{
+			InputMint:            order.BaseMint,
+			OutputMint:           order.QuoteMint,
+			InputAmount:          inputAmount,
+			OutputAmount:         outputAmount,
+			UseExactOutputAmount: useExactOutput,
+			MinFillSize:          api_types.NewStringAmountFromBigInt((*big.Int)(&order.MinFillSize)),
+		}
+	}
+}
+
+// ---------------------
+// | Quote Conversions |
+// ---------------------
+
+// invertPriceString inverts a price string (computes 1/price)
+func invertPriceString(priceStr string) (string, error) {
+	price, err := strconv.ParseFloat(priceStr, 64)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse price: %w", err)
+	}
+	if price == 0.0 {
+		return "0", nil
+	}
+	inverted := 1.0 / price
+	return strconv.FormatFloat(inverted, 'g', -1, 64), nil
+}
+
+// v2QuoteToV1 converts a v2 SignedExternalQuoteV2 to a v1 ApiSignedQuote
+func v2QuoteToV1(
+	v2Quote *SignedExternalQuoteV2,
+	originalOrder *api_types.ApiExternalOrder,
+) (*api_types.ApiSignedQuote, error) {
+	q := &v2Quote.Quote
+	direction := originalOrder.Side
+
+	// Map v2 input/output to v1 base/quote based on direction
+	var quoteMint, baseMint string
+	var quoteAmount, baseAmount api_types.Amount
+	switch direction {
+	case "Buy":
+		quoteMint = q.MatchResult.InputMint
+		baseMint = q.MatchResult.OutputMint
+		quoteAmount = api_types.Amount(*q.MatchResult.InputAmount.ToBigInt())
+		baseAmount = api_types.Amount(*q.MatchResult.OutputAmount.ToBigInt())
+	default: // Sell
+		quoteMint = q.MatchResult.OutputMint
+		baseMint = q.MatchResult.InputMint
+		quoteAmount = api_types.Amount(*q.MatchResult.OutputAmount.ToBigInt())
+		baseAmount = api_types.Amount(*q.MatchResult.InputAmount.ToBigInt())
+	}
+
+	v1MatchResult := api_types.ApiExternalMatchResult{
+		QuoteMint:   quoteMint,
+		BaseMint:    baseMint,
+		QuoteAmount: quoteAmount,
+		BaseAmount:  baseAmount,
+		Direction:   direction,
+	}
+
+	// Convert price from v2's output/input to v1's quote/base
+	var v1Price api_types.TimestampedPrice
+	switch direction {
+	case "Buy":
+		invertedPrice, err := invertPriceString(q.Price.Price)
+		if err != nil {
+			return nil, err
+		}
+		v1Price = api_types.TimestampedPrice{
+			Price:     invertedPrice,
+			Timestamp: q.Price.Timestamp,
+		}
+	default: // Sell
+		v1Price = q.Price
+	}
+
+	// Convert v2 send/receive (StringAmount) to v1 (Amount)
+	v1Send := api_types.ApiExternalAssetTransfer{
+		Mint:   q.Send.Mint,
+		Amount: api_types.Amount(*q.Send.Amount.ToBigInt()),
+	}
+	v1Receive := api_types.ApiExternalAssetTransfer{
+		Mint:   q.Receive.Mint,
+		Amount: api_types.Amount(*q.Receive.Amount.ToBigInt()),
+	}
+
+	// Convert v2 fees (StringAmount) to v1 (Amount)
+	v1Fees := api_types.ApiFee{
+		RelayerFee:  api_types.Amount(*q.Fees.RelayerFee.ToBigInt()),
+		ProtocolFee: api_types.Amount(*q.Fees.ProtocolFee.ToBigInt()),
+	}
+
+	v1Quote := api_types.ApiExternalQuote{
+		Order:       *originalOrder,
+		MatchResult: v1MatchResult,
+		Fees:        v1Fees,
+		Send:        v1Send,
+		Receive:     v1Receive,
+		Price:       v1Price,
+		Timestamp:   q.Timestamp,
+	}
+
+	// Build the gas sponsorship info wrapper
+	var gasSponsorshipInfo *api_types.ApiSignedGasSponsorshipInfo
+	if v2Quote.GasSponsorshipInfo != nil {
+		gasSponsorshipInfo = &api_types.ApiSignedGasSponsorshipInfo{
+			GasSponsorshipInfo: *v2Quote.GasSponsorshipInfo,
+		}
+	}
+
+	// Store the original v2 ApiSignedQuote for round-tripping
+	innerV2 := &api_types.ApiSignedQuoteV2{
+		Quote:     v2Quote.Quote,
+		Signature: v2Quote.Signature,
+		Deadline:  v2Quote.Deadline,
+	}
+
+	return api_types.NewApiSignedQuote(
+		v1Quote,
+		v2Quote.Signature,
+		v2Quote.Deadline,
+		gasSponsorshipInfo,
+		innerV2,
+	), nil
+}
+
+// v1QuoteToV2 extracts the v2 SignedExternalQuoteV2 from a v1 ApiSignedQuote
+// for use in the assemble flow
+func v1QuoteToV2(v1 *api_types.ApiSignedQuote) (*SignedExternalQuoteV2, error) {
+	innerV2 := v1.InnerV2Quote()
+	if innerV2 == nil {
+		return nil, fmt.Errorf("ApiSignedQuote has no inner v2 quote for round-tripping")
+	}
+
+	var gasInfo *api_types.ApiGasSponsorshipInfo
+	if v1.GasSponsorshipInfo != nil {
+		gasInfo = &v1.GasSponsorshipInfo.GasSponsorshipInfo
+	}
+
+	return &SignedExternalQuoteV2{
+		Quote:              innerV2.Quote,
+		Signature:          innerV2.Signature,
+		Deadline:           innerV2.Deadline,
+		GasSponsorshipInfo: gasInfo,
+	}, nil
+}
+
+// -------------------------
+// | Response Conversions  |
+// -------------------------
+
+// decodeInputAmountFromCalldata reads the input amount from settlement tx calldata bytes 4-36
+func decodeInputAmountFromCalldata(tx *api_types.ApiSettlementTransactionV2) (*big.Int, error) {
+	// The input field is a hex string; convert to raw bytes
+	dataBytes := geth_common.FromHex(tx.Input)
+	end := inputAmountOffset + amountCalldataLength
+
+	if len(dataBytes) < end {
+		return nil, fmt.Errorf("invalid calldata: too short (len=%d, need=%d)", len(dataBytes), end)
+	}
+
+	inputSlice := dataBytes[inputAmountOffset:end]
+	return new(big.Int).SetBytes(inputSlice), nil
+}
+
+// v2ResponseToV1NonMalleable converts a v2 ExternalMatchResponseV2 to a v1 ExternalMatchBundle
+func v2ResponseToV1NonMalleable(
+	resp *api_types.ExternalMatchResponseV2,
+	direction string,
+) (*ExternalMatchBundle, error) {
+	matchResult := &resp.MatchBundle.MatchResult
+	priceFp := &matchResult.PriceFp
+
+	// Decode the input amount from the calldata
+	inputAmount, err := decodeInputAmountFromCalldata(&resp.MatchBundle.SettlementTx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode input amount: %w", err)
+	}
+
+	// Compute output amount from price
+	outputAmount := priceFp.FloorMulInt(inputAmount)
+
+	// Map v2 input/output to v1 base/quote based on direction
+	var quoteMint, baseMint string
+	var quoteAmount, baseAmount *big.Int
+	switch direction {
+	case "Buy":
+		quoteMint = matchResult.InputMint
+		baseMint = matchResult.OutputMint
+		quoteAmount = inputAmount
+		baseAmount = outputAmount
+	default: // Sell
+		quoteMint = matchResult.OutputMint
+		baseMint = matchResult.InputMint
+		quoteAmount = outputAmount
+		baseAmount = inputAmount
+	}
+
+	v1MatchResult := &api_types.ApiExternalMatchResult{
+		QuoteMint:   quoteMint,
+		BaseMint:    baseMint,
+		QuoteAmount: api_types.Amount(*quoteAmount),
+		BaseAmount:  api_types.Amount(*baseAmount),
+		Direction:   direction,
+	}
+
+	// Compute fees from fee_rates and output amount
+	totalFeeRate := resp.MatchBundle.FeeRates.Total()
+	totalFee := totalFeeRate.FloorMulInt(outputAmount)
+	relayerFee := resp.MatchBundle.FeeRates.RelayerFeeRate.FloorMulInt(outputAmount)
+	protocolFee := new(big.Int).Sub(totalFee, relayerFee)
+
+	v1Fees := &api_types.ApiFee{
+		RelayerFee:  api_types.Amount(*relayerFee),
+		ProtocolFee: api_types.Amount(*protocolFee),
+	}
+
+	// Compute receive/send: fees are subtracted from receive (output) side
+	var receive, send *api_types.ApiExternalAssetTransfer
+	switch direction {
+	case "Buy":
+		recvAmount := new(big.Int).Sub(baseAmount, totalFee)
+		receive = &api_types.ApiExternalAssetTransfer{
+			Mint:   baseMint,
+			Amount: api_types.Amount(*recvAmount),
+		}
+		send = &api_types.ApiExternalAssetTransfer{
+			Mint:   quoteMint,
+			Amount: api_types.Amount(*quoteAmount),
+		}
+	default: // Sell
+		recvAmount := new(big.Int).Sub(quoteAmount, totalFee)
+		receive = &api_types.ApiExternalAssetTransfer{
+			Mint:   quoteMint,
+			Amount: api_types.Amount(*recvAmount),
+		}
+		send = &api_types.ApiExternalAssetTransfer{
+			Mint:   baseMint,
+			Amount: api_types.Amount(*baseAmount),
+		}
+	}
+
+	gasSponsored := resp.GasSponsorshipInfo != nil
+
+	return &ExternalMatchBundle{
+		MatchResult:        v1MatchResult,
+		Fees:               v1Fees,
+		Receive:            receive,
+		Send:               send,
+		SettlementTx:       toSettlementTransactionV2(&resp.MatchBundle.SettlementTx),
+		GasSponsored:       gasSponsored,
+		GasSponsorshipInfo: resp.GasSponsorshipInfo,
+	}, nil
+}
+
+// --------------------------
+// | Options Conversions    |
+// --------------------------
+
+// v1AssembleOptionsToV2 converts v1 AssembleExternalMatchOptions to v2 AssembleExternalMatchOptionsV2
+func v1AssembleOptionsToV2(
+	opts *AssembleExternalMatchOptions,
+	originalOrder *api_types.ApiExternalOrder,
+) *AssembleExternalMatchOptionsV2 {
+	v2Opts := &AssembleExternalMatchOptionsV2{
+		DoGasEstimation: opts.DoGasEstimation,
+		ReceiverAddress: opts.ReceiverAddress,
+	}
+	if opts.UpdatedOrder != nil {
+		v2Order := v1OrderToV2(opts.UpdatedOrder)
+		v2Opts.UpdatedOrder = &v2Order
+	} else if originalOrder != nil {
+		// No updated order; use the original order converted to v2
+		// (not needed for assemble — server uses the quote's order)
+	}
+	return v2Opts
+}
+
+// --------------------------
+// | Market Data Conversions |
+// --------------------------
+
+// marketsToSupportedTokens converts a GetMarketsResponse to a list of unique ApiToken
+func marketsToSupportedTokens(resp *api_types.GetMarketsResponse) []api_types.ApiToken {
+	seen := make(map[string]bool)
+	var tokens []api_types.ApiToken
+	for _, market := range resp.Markets {
+		if !seen[market.Base.Address] {
+			seen[market.Base.Address] = true
+			tokens = append(tokens, market.Base)
+		}
+		if !seen[market.Quote.Address] {
+			seen[market.Quote.Address] = true
+			tokens = append(tokens, market.Quote)
+		}
+	}
+	return tokens
+}
+
+// marketsToFeeForAsset finds a market containing the given asset and returns the fee rates
+// as an ExternalMatchFee (float64 values)
+func marketsToFeeForAsset(resp *api_types.GetMarketsResponse, addr string) (*ExternalMatchFee, error) {
+	for _, market := range resp.Markets {
+		if market.Base.Address == addr || market.Quote.Address == addr {
+			return &ExternalMatchFee{
+				RelayerFee:  market.ExternalMatchFeeRates.RelayerFeeRate.ToF64(),
+				ProtocolFee: market.ExternalMatchFeeRates.ProtocolFeeRate.ToF64(),
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("no market found for asset: %s", addr)
+}

--- a/client/external_match_client/v2_types.go
+++ b/client/external_match_client/v2_types.go
@@ -1,0 +1,315 @@
+package external_match_client //nolint:revive
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/renegade-fi/golang-sdk/client/api_types"
+)
+
+// NativeAssetAddr is the sentinel address for native ETH
+const NativeAssetAddr = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+
+// inputAmountOffset is the byte offset of the input amount in settlement tx calldata
+// (after the 4-byte function selector)
+const inputAmountOffset = 4
+
+// amountCalldataLength is the length of a uint256 in calldata (32 bytes)
+const amountCalldataLength = 32
+
+// --------------------------
+// | SignedExternalQuoteV2 |
+// --------------------------
+
+// SignedExternalQuoteV2 is the application-level v2 signed quote
+type SignedExternalQuoteV2 struct {
+	Quote              api_types.ApiExternalQuoteV2
+	Signature          string
+	Deadline           uint64
+	GasSponsorshipInfo *api_types.ApiGasSponsorshipInfo
+}
+
+// NewSignedExternalQuoteV2 creates a SignedExternalQuoteV2 from an API response
+func NewSignedExternalQuoteV2(resp *api_types.ExternalQuoteResponseV2) *SignedExternalQuoteV2 {
+	return &SignedExternalQuoteV2{
+		Quote:              resp.SignedQuote.Quote,
+		Signature:          resp.SignedQuote.Signature,
+		Deadline:           resp.SignedQuote.Deadline,
+		GasSponsorshipInfo: resp.GasSponsorshipInfo,
+	}
+}
+
+// MatchResult returns the match result from the quote
+func (q *SignedExternalQuoteV2) MatchResult() api_types.ApiExternalMatchResultV2 {
+	return q.Quote.MatchResult
+}
+
+// Fees returns the fees from the quote
+func (q *SignedExternalQuoteV2) Fees() api_types.FeeTake {
+	return q.Quote.Fees
+}
+
+// ReceiveAmount returns the receive transfer from the quote
+func (q *SignedExternalQuoteV2) ReceiveAmount() api_types.ApiExternalAssetTransferV2 {
+	return q.Quote.Receive
+}
+
+// SendAmount returns the send transfer from the quote
+func (q *SignedExternalQuoteV2) SendAmount() api_types.ApiExternalAssetTransferV2 {
+	return q.Quote.Send
+}
+
+// ToApiSignedQuote converts to the API wire format (without gas info)
+func (q *SignedExternalQuoteV2) ToApiSignedQuote() api_types.ApiSignedQuoteV2 {
+	return api_types.ApiSignedQuoteV2{
+		Quote:     q.Quote,
+		Signature: q.Signature,
+		Deadline:  q.Deadline,
+	}
+}
+
+// ---------------------------------
+// | MalleableExternalMatchBundle |
+// ---------------------------------
+
+// MalleableExternalMatchBundle is the application-level v2 match bundle
+// with support for malleable (bounded) input amounts
+type MalleableExternalMatchBundle struct {
+	MatchResult        *api_types.ApiBoundedMatchResultV2
+	FeeRates           *api_types.FeeTakeRate
+	MaxReceive         *api_types.ApiExternalAssetTransferV2
+	MinReceive         *api_types.ApiExternalAssetTransferV2
+	MaxSend            *api_types.ApiExternalAssetTransferV2
+	MinSend            *api_types.ApiExternalAssetTransferV2
+	SettlementTx       *SettlementTransaction
+	Deadline           uint64
+	GasSponsorshipInfo *api_types.ApiGasSponsorshipInfo
+	inputAmount        *big.Int // set by SetInputAmount; unexported
+}
+
+// newMalleableExternalMatchBundle creates a MalleableExternalMatchBundle from an API response
+func newMalleableExternalMatchBundle(resp *api_types.ExternalMatchResponseV2) *MalleableExternalMatchBundle {
+	return &MalleableExternalMatchBundle{
+		MatchResult:        &resp.MatchBundle.MatchResult,
+		FeeRates:           &resp.MatchBundle.FeeRates,
+		MaxReceive:         &resp.MatchBundle.MaxReceive,
+		MinReceive:         &resp.MatchBundle.MinReceive,
+		MaxSend:            &resp.MatchBundle.MaxSend,
+		MinSend:            &resp.MatchBundle.MinSend,
+		SettlementTx:       toSettlementTransactionV2(&resp.MatchBundle.SettlementTx),
+		Deadline:           resp.MatchBundle.Deadline,
+		GasSponsorshipInfo: resp.GasSponsorshipInfo,
+	}
+}
+
+// InputBounds returns the (min, max) input amount bounds
+func (b *MalleableExternalMatchBundle) InputBounds() (min, max *big.Int) {
+	return b.MatchResult.MinInputAmount.ToBigInt(), b.MatchResult.MaxInputAmount.ToBigInt()
+}
+
+// OutputBounds returns the (min, max) output amount bounds
+// Computed from the price and input bounds
+func (b *MalleableExternalMatchBundle) OutputBounds() (min, max *big.Int) {
+	minInput, maxInput := b.InputBounds()
+	price := &b.MatchResult.PriceFp
+
+	minOutput := price.FloorMulInt(minInput)
+	maxOutput := price.FloorMulInt(maxInput)
+
+	return minOutput, maxOutput
+}
+
+// currentInputAmount returns the currently set input amount, defaulting to max
+func (b *MalleableExternalMatchBundle) currentInputAmount() *big.Int {
+	if b.inputAmount != nil {
+		return b.inputAmount
+	}
+	return b.MatchResult.MaxInputAmount.ToBigInt()
+}
+
+// outputAmount computes the output amount at the given input
+func (b *MalleableExternalMatchBundle) outputAmount(inputAmount *big.Int) *big.Int {
+	return b.MatchResult.PriceFp.FloorMulInt(inputAmount)
+}
+
+// computeReceiveAmount computes the receive (output) amount net of fees
+func (b *MalleableExternalMatchBundle) computeReceiveAmount(inputAmount *big.Int) *big.Int {
+	preSponsoredAmt := b.outputAmount(inputAmount)
+
+	// Subtract fees
+	totalFeeRate := b.FeeRates.Total()
+	totalFeeAmount := totalFeeRate.FloorMulInt(preSponsoredAmt)
+	preSponsoredAmt = new(big.Int).Sub(preSponsoredAmt, totalFeeAmount)
+
+	// Add gas sponsorship refund if in-kind (not native ETH)
+	if b.GasSponsorshipInfo != nil && !b.GasSponsorshipInfo.RefundNativeETH {
+		refund := (*big.Int)(&b.GasSponsorshipInfo.RefundAmount)
+		preSponsoredAmt = new(big.Int).Add(preSponsoredAmt, refund)
+	}
+
+	return preSponsoredAmt
+}
+
+// ReceiveAmount returns the receive amount at the currently set input amount
+func (b *MalleableExternalMatchBundle) ReceiveAmount() *big.Int {
+	return b.computeReceiveAmount(b.currentInputAmount())
+}
+
+// ReceiveAmountAtInput returns the receive amount at a specific input amount
+func (b *MalleableExternalMatchBundle) ReceiveAmountAtInput(inputAmount *big.Int) *big.Int {
+	return b.computeReceiveAmount(inputAmount)
+}
+
+// SendAmount returns the current send amount
+func (b *MalleableExternalMatchBundle) SendAmount() *big.Int {
+	return b.currentInputAmount()
+}
+
+// isNativeEthSell returns whether the trade is a native ETH sell
+func (b *MalleableExternalMatchBundle) isNativeEthSell() bool {
+	return strings.EqualFold(b.MatchResult.InputMint, NativeAssetAddr)
+}
+
+// checkInputAmount validates that the input amount is within bounds
+func (b *MalleableExternalMatchBundle) checkInputAmount(inputAmount *big.Int) error {
+	minInput, maxInput := b.InputBounds()
+	if inputAmount.Cmp(minInput) < 0 || inputAmount.Cmp(maxInput) > 0 {
+		return fmt.Errorf("invalid input amount: must be between %s and %s, got %s",
+			minInput.String(), maxInput.String(), inputAmount.String())
+	}
+	return nil
+}
+
+// SetInputAmount sets the input amount, modifies the settlement tx calldata,
+// and returns the resulting receive amount.
+// The amount must be within the input bounds.
+func (b *MalleableExternalMatchBundle) SetInputAmount(amount *big.Int) (*big.Int, error) {
+	if err := b.checkInputAmount(amount); err != nil {
+		return nil, err
+	}
+
+	// Modify the calldata
+	b.setInputAmountCalldata(amount)
+
+	// Store the input amount
+	b.inputAmount = new(big.Int).Set(amount)
+
+	return b.ReceiveAmount(), nil
+}
+
+// setInputAmountCalldata writes the input amount into the settlement tx calldata
+func (b *MalleableExternalMatchBundle) setInputAmountCalldata(inputAmount *big.Int) {
+	data := b.SettlementTx.Data
+	end := inputAmountOffset + amountCalldataLength
+
+	// ABI-encode the amount as a 32-byte big-endian uint256
+	amountBytes := inputAmount.Bytes()
+	encoded := make([]byte, amountCalldataLength)
+	// Left-pad with zeros
+	copy(encoded[amountCalldataLength-len(amountBytes):], amountBytes)
+
+	// Write into calldata at bytes 4-36
+	copy(data[inputAmountOffset:end], encoded)
+
+	// If native ETH sell, also update the tx value
+	if b.isNativeEthSell() {
+		b.SettlementTx.Value = new(big.Int).Set(inputAmount)
+	}
+}
+
+// GetSettlementTx returns the parsed settlement transaction
+func (b *MalleableExternalMatchBundle) GetSettlementTx() *SettlementTransaction {
+	return b.SettlementTx
+}
+
+// -----------------
+// | Options Types |
+// -----------------
+
+// AssembleExternalMatchOptionsV2 represents options for a v2 assembly request
+type AssembleExternalMatchOptionsV2 struct {
+	DoGasEstimation bool
+	ReceiverAddress *string
+	UpdatedOrder    *api_types.ApiExternalOrderV2
+}
+
+// NewAssembleExternalMatchOptionsV2 creates default v2 assembly options
+func NewAssembleExternalMatchOptionsV2() *AssembleExternalMatchOptionsV2 {
+	return &AssembleExternalMatchOptionsV2{}
+}
+
+// WithGasEstimation sets the gas estimation flag
+func (o *AssembleExternalMatchOptionsV2) WithGasEstimation(estimate bool) *AssembleExternalMatchOptionsV2 {
+	o.DoGasEstimation = estimate
+	return o
+}
+
+// WithReceiverAddress sets the receiver address
+func (o *AssembleExternalMatchOptionsV2) WithReceiverAddress(address *string) *AssembleExternalMatchOptionsV2 {
+	o.ReceiverAddress = address
+	return o
+}
+
+// WithUpdatedOrder sets the updated order
+func (o *AssembleExternalMatchOptionsV2) WithUpdatedOrder(order *api_types.ApiExternalOrderV2) *AssembleExternalMatchOptionsV2 {
+	o.UpdatedOrder = order
+	return o
+}
+
+// ExternalMatchOptionsV2 represents options for a v2 direct match request
+type ExternalMatchOptionsV2 struct {
+	DoGasEstimation       bool
+	ReceiverAddress       *string
+	DisableGasSponsorship bool
+	GasRefundAddress      *string
+	RefundNativeEth       bool
+}
+
+// NewExternalMatchOptionsV2 creates default v2 match options
+func NewExternalMatchOptionsV2() *ExternalMatchOptionsV2 {
+	return &ExternalMatchOptionsV2{}
+}
+
+// WithGasEstimation sets the gas estimation flag
+func (o *ExternalMatchOptionsV2) WithGasEstimation(estimate bool) *ExternalMatchOptionsV2 {
+	o.DoGasEstimation = estimate
+	return o
+}
+
+// WithReceiverAddress sets the receiver address
+func (o *ExternalMatchOptionsV2) WithReceiverAddress(address *string) *ExternalMatchOptionsV2 {
+	o.ReceiverAddress = address
+	return o
+}
+
+// WithDisableGasSponsorship disables gas sponsorship
+func (o *ExternalMatchOptionsV2) WithDisableGasSponsorship(disable bool) *ExternalMatchOptionsV2 {
+	o.DisableGasSponsorship = disable
+	return o
+}
+
+// WithGasRefundAddress sets the gas refund address
+func (o *ExternalMatchOptionsV2) WithGasRefundAddress(address *string) *ExternalMatchOptionsV2 {
+	o.GasRefundAddress = address
+	return o
+}
+
+// WithRefundNativeEth sets whether to refund in native ETH
+func (o *ExternalMatchOptionsV2) WithRefundNativeEth(refund bool) *ExternalMatchOptionsV2 {
+	o.RefundNativeEth = refund
+	return o
+}
+
+// BuildRequestPath builds the request path for the v2 match options
+func (o *ExternalMatchOptionsV2) BuildRequestPath() string {
+	path := api_types.AssembleMatchBundleV2Path
+	path += fmt.Sprintf("?%s=%t", api_types.DisableGasSponsorshipParam, o.DisableGasSponsorship)
+	if o.RefundNativeEth {
+		path += fmt.Sprintf("&%s=%t", api_types.RefundNativeEthParam, o.RefundNativeEth)
+	}
+	if o.GasRefundAddress != nil {
+		path += fmt.Sprintf("&%s=%s", api_types.GasRefundAddressParam, *o.GasRefundAddress)
+	}
+	return path
+}

--- a/examples/02_external_quote_validation/main.go
+++ b/examples/02_external_quote_validation/main.go
@@ -198,5 +198,10 @@ func getPrivateKey() (*ecdsa.PrivateKey, error) {
 		return nil, fmt.Errorf("PKEY environment variable not set")
 	}
 
+	// Strip 0x prefix if present
+	if len(privKeyHex) > 2 && privKeyHex[:2] == "0x" {
+		privKeyHex = privKeyHex[2:]
+	}
+
 	return crypto.HexToECDSA(privKeyHex)
 }

--- a/examples/common/client.go
+++ b/examples/common/client.go
@@ -41,10 +41,22 @@ func CreateBaseExternalMatchClient() (*external_match_client.ExternalMatchClient
 	return external_match_client.NewBaseSepoliaExternalMatchClient(apiKey, &apiSecretKey), nil
 }
 
-// FindTokenAddr fetches the address of a token from the relayer
+// testnetTokenAddresses contains fallback token addresses for Arbitrum Sepolia
+var testnetTokenAddresses = map[string]string{
+	"USDC": "0xdf8d259c04020562717557f2b5a3cf28e92707d1",
+	"WETH": "0xc3414a7ef14aaaa9c4522dfc00a4e66e74e9c25a",
+}
+
+// FindTokenAddr fetches the address of a token from the relayer,
+// falling back to hardcoded testnet addresses if the API is unavailable
 func FindTokenAddr(symbol string, client *external_match_client.ExternalMatchClient) (string, error) {
 	tokens, err := client.GetSupportedTokens()
 	if err != nil {
+		// Fallback to hardcoded testnet addresses
+		if addr, ok := testnetTokenAddresses[symbol]; ok {
+			fmt.Printf("Warning: GetSupportedTokens failed (%v), using hardcoded address for %s\n", err, symbol)
+			return addr, nil
+		}
 		return "", err
 	}
 

--- a/examples/common/eth.go
+++ b/examples/common/eth.go
@@ -89,6 +89,11 @@ func GetPrivateKey() (*ecdsa.PrivateKey, error) {
 		return nil, fmt.Errorf("PKEY environment variable not set")
 	}
 
+	// Strip 0x prefix if present
+	if len(privKeyHex) > 2 && privKeyHex[:2] == "0x" {
+		privKeyHex = privKeyHex[2:]
+	}
+
 	return crypto.HexToECDSA(privKeyHex)
 }
 


### PR DESCRIPTION
In this PR, we implement the v2 external match client w/ backwards-compatibility shims to preserve the v1 interface.

All external match examples have been tested, and all which are currently supported by the relayer pass.